### PR TITLE
Add explanatory diagrams to log posts

### DIFF
--- a/site/public/images/log/atom-structure.svg
+++ b/site/public/images/log/atom-structure.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 340" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif">
+  <style>
+    text { fill: #1a1a1a; }
+    .label { font-size: 11px; fill: #6b6b6b; }
+    .field { font-size: 12px; font-weight: 500; }
+    .value { font-size: 11px; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+    .title { font-size: 13px; font-weight: 600; }
+    .note { font-size: 10px; fill: #6b6b6b; font-style: italic; }
+  </style>
+
+  <text x="280" y="24" text-anchor="middle" class="title">Atom: the deviation frame</text>
+  <text x="280" y="42" text-anchor="middle" class="label">From the stress test — the book's most valuable pattern</text>
+
+  <!-- Main atom box -->
+  <rect x="40" y="60" width="480" height="240" rx="10" fill="#fafaf8" stroke="#e0ddd8" stroke-width="1.5"/>
+
+  <!-- Frame type -->
+  <text x="70" y="92" class="field">frame</text>
+  <rect x="160" y="76" width="120" height="24" rx="5" fill="#fef3f2" stroke="#e0ddd8"/>
+  <text x="220" y="93" text-anchor="middle" class="value">deviation</text>
+
+  <!-- Roles -->
+  <text x="70" y="128" class="field">roles</text>
+
+  <rect x="160" y="112" width="340" height="76" rx="6" fill="#f0f7f0" stroke="#c8dcc8"/>
+
+  <text x="178" y="133" class="label">theory:</text>
+  <text x="230" y="133" class="value">"Demand grows linearly with population"</text>
+
+  <text x="178" y="155" class="label">reality:</text>
+  <text x="230" y="155" class="value">"Demand plateaus due to saturation effects"</text>
+
+  <text x="178" y="177" class="label">implication:</text>
+  <text x="250" y="177" class="value">"Forecasts overestimate by 30-40%"</text>
+
+  <!-- Conditions -->
+  <text x="70" y="214" class="field">conditions</text>
+  <text x="178" y="214" class="value">"mature markets with &gt;60% penetration"</text>
+
+  <!-- Confidence -->
+  <text x="70" y="240" class="field">confidence</text>
+  <rect x="160" y="226" width="80" height="20" rx="4" fill="#e8f5e8" stroke="#c8dcc8"/>
+  <text x="200" y="241" text-anchor="middle" class="value">0.85</text>
+
+  <!-- Source -->
+  <text x="70" y="268" class="field">source</text>
+  <text x="178" y="268" class="value" style="fill:#6b6b6b;">Industry Analysis, Ch. 4, p. 112</text>
+
+  <!-- Bottom annotation -->
+  <text x="280" y="324" text-anchor="middle" class="note">Three roles capture theory vs. reality — something a 2-role triple can't express in one atom.</text>
+</svg>

--- a/site/public/images/log/cost-split.svg
+++ b/site/public/images/log/cost-split.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 260" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif">
+  <style>
+    text { fill: #1a1a1a; }
+    .label { font-size: 10px; fill: #6b6b6b; }
+    .stage { font-size: 11px; font-weight: 500; }
+    .title { font-size: 13px; font-weight: 600; }
+    .mono { font-family: 'SF Mono', Menlo, Consolas, monospace; font-size: 10px; }
+    .cost { font-size: 10px; font-weight: 600; }
+  </style>
+
+  <defs>
+    <marker id="a" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5" fill="none" stroke="#2d2d2d" stroke-width="1"/>
+    </marker>
+    <marker id="a2" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5" fill="none" stroke="#6b6b6b" stroke-width="1"/>
+    </marker>
+  </defs>
+
+  <text x="310" y="24" text-anchor="middle" class="title">The cost insight</text>
+  <text x="310" y="42" text-anchor="middle" class="label">Comprehension is expensive but rare. Extraction is cheap but frequent.</text>
+
+  <!-- Chapter input -->
+  <rect x="20" y="80" width="80" height="50" rx="8" fill="#fafaf8" stroke="#e0ddd8"/>
+  <text x="60" y="102" text-anchor="middle" class="stage">Chapter</text>
+  <text x="60" y="116" text-anchor="middle" class="label">~50 pages</text>
+
+  <line x1="100" y1="105" x2="140" y2="105" stroke="#2d2d2d" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <!-- Comprehension (expensive) -->
+  <rect x="142" y="68" width="150" height="74" rx="8" fill="#fef3f2" stroke="#e8c4c0"/>
+  <text x="217" y="92" text-anchor="middle" class="stage">Comprehend</text>
+  <text x="217" y="108" text-anchor="middle" class="cost" fill="#c0392b">1 call · capable model</text>
+  <text x="217" y="124" text-anchor="middle" class="label">~20% of cost</text>
+  <text x="217" y="136" text-anchor="middle" class="label">highest leverage</text>
+
+  <line x1="292" y1="105" x2="332" y2="105" stroke="#2d2d2d" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <!-- Comprehension map -->
+  <rect x="334" y="80" width="110" height="50" rx="8" fill="#fafaf8" stroke="#2d2d2d" stroke-width="1.5"/>
+  <text x="389" y="100" text-anchor="middle" class="stage">Comprehension</text>
+  <text x="389" y="116" text-anchor="middle" class="stage">Map</text>
+
+  <!-- Fan out arrows -->
+  <line x1="444" y1="95" x2="490" y2="175" stroke="#6b6b6b" stroke-width="1" marker-end="url(#a2)"/>
+  <line x1="444" y1="100" x2="490" y2="200" stroke="#6b6b6b" stroke-width="1" marker-end="url(#a2)"/>
+  <line x1="444" y1="105" x2="490" y2="225" stroke="#6b6b6b" stroke-width="1" marker-end="url(#a2)"/>
+
+  <!-- Label on fan -->
+  <text x="472" y="165" class="label" text-anchor="middle">guides</text>
+
+  <!-- Extraction calls (cheap) -->
+  <rect x="492" y="166" width="110" height="26" rx="5" fill="#f0f7f0" stroke="#c8dcc8"/>
+  <text x="547" y="183" text-anchor="middle" class="mono">Extract § 4.1</text>
+
+  <rect x="492" y="196" width="110" height="26" rx="5" fill="#f0f7f0" stroke="#c8dcc8"/>
+  <text x="547" y="213" text-anchor="middle" class="mono">Extract § 4.2</text>
+
+  <rect x="492" y="226" width="110" height="26" rx="5" fill="#f0f7f0" stroke="#c8dcc8"/>
+  <text x="547" y="243" text-anchor="middle" class="mono">Extract § 4.3 …</text>
+
+  <!-- Cost label for extraction -->
+  <text x="547" y="156" text-anchor="middle" class="cost" fill="#27763a">N calls · cheap model</text>
+  <text x="547" y="144" text-anchor="middle" class="label">~80% of calls, ~20% of cost</text>
+</svg>

--- a/site/public/images/log/triple-vs-frame.svg
+++ b/site/public/images/log/triple-vs-frame.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 320" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif">
+  <style>
+    text { fill: #1a1a1a; }
+    .label { font-size: 11px; fill: #6b6b6b; }
+    .title { font-size: 13px; font-weight: 600; }
+    .role { font-size: 11px; }
+    .dim { fill: #6b6b6b; }
+    .strike { text-decoration: line-through; fill: #b0b0b0; }
+  </style>
+
+  <!-- Triple (left) -->
+  <text x="160" y="28" text-anchor="middle" class="title">Triple</text>
+  <text x="160" y="46" text-anchor="middle" class="label">2 roles only</text>
+
+  <rect x="40" y="70" width="100" height="36" rx="6" fill="#fef3f2" stroke="#e0ddd8"/>
+  <text x="90" y="93" text-anchor="middle" class="role">Subject</text>
+
+  <rect x="180" y="70" width="100" height="36" rx="6" fill="#fef3f2" stroke="#e0ddd8"/>
+  <text x="230" y="93" text-anchor="middle" class="role">Object</text>
+
+  <line x1="140" y1="88" x2="180" y2="88" stroke="#b0b0b0" stroke-width="1.5" marker-end="url(#arrow-dim)"/>
+  <text x="160" y="80" text-anchor="middle" class="label">relation</text>
+
+  <!-- Triple example -->
+  <rect x="20" y="130" width="280" height="80" rx="8" fill="#fafaf8" stroke="#e0ddd8" stroke-dasharray="4,3"/>
+  <text x="160" y="152" text-anchor="middle" class="label">Example: "buying"</text>
+  <text x="160" y="174" text-anchor="middle" class="role dim">(buyer) → buys → (goods)</text>
+  <text x="160" y="194" text-anchor="middle" class="label" style="fill:#c0392b;">Where do seller, money, terms go?</text>
+
+  <!-- Arrow between -->
+  <line x1="330" y1="140" x2="370" y2="140" stroke="#2d2d2d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Frame (right) -->
+  <text x="540" y="28" text-anchor="middle" class="title">Micro-Frame</text>
+  <text x="540" y="46" text-anchor="middle" class="label">N named roles</text>
+
+  <rect x="400" y="64" width="280" height="160" rx="10" fill="#f0f7f0" stroke="#c8dcc8"/>
+
+  <text x="420" y="88" class="label">frame:</text>
+  <text x="480" y="88" class="role">Commercial Transaction</text>
+
+  <text x="420" y="112" class="label">roles:</text>
+
+  <rect x="480" y="98" width="80" height="22" rx="4" fill="#e8f5e8" stroke="#c8dcc8"/>
+  <text x="520" y="114" text-anchor="middle" class="role">Buyer</text>
+
+  <rect x="568" y="98" width="80" height="22" rx="4" fill="#e8f5e8" stroke="#c8dcc8"/>
+  <text x="608" y="114" text-anchor="middle" class="role">Seller</text>
+
+  <rect x="480" y="126" width="80" height="22" rx="4" fill="#e8f5e8" stroke="#c8dcc8"/>
+  <text x="520" y="142" text-anchor="middle" class="role">Goods</text>
+
+  <rect x="568" y="126" width="80" height="22" rx="4" fill="#e8f5e8" stroke="#c8dcc8"/>
+  <text x="608" y="142" text-anchor="middle" class="role">Money</text>
+
+  <text x="420" y="170" class="label">conditions:</text>
+  <text x="500" y="170" class="role dim">[...]</text>
+
+  <text x="420" y="192" class="label">confidence:</text>
+  <text x="500" y="192" class="role dim">0.0 – 1.0</text>
+
+  <text x="420" y="214" class="label">source:</text>
+  <text x="500" y="214" class="role dim">{title, location}</text>
+
+  <!-- Bottom note -->
+  <text x="360" y="290" text-anchor="middle" class="label">Simple binary relations are frames with two roles — nothing is lost.</text>
+  <text x="360" y="308" text-anchor="middle" class="label">Complex structures gain the roles they need.</text>
+
+  <!-- Arrow markers -->
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#2d2d2d" stroke-width="1.2"/>
+    </marker>
+    <marker id="arrow-dim" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#b0b0b0" stroke-width="1.2"/>
+    </marker>
+  </defs>
+</svg>

--- a/site/public/images/log/two-pipelines.svg
+++ b/site/public/images/log/two-pipelines.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 300" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif">
+  <style>
+    text { fill: #1a1a1a; }
+    .label { font-size: 10px; fill: #6b6b6b; }
+    .stage { font-size: 11px; font-weight: 500; }
+    .title { font-size: 13px; font-weight: 600; }
+    .pipe-label { font-size: 12px; font-weight: 600; }
+  </style>
+
+  <defs>
+    <marker id="arr" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5" fill="none" stroke="#2d2d2d" stroke-width="1"/>
+    </marker>
+    <marker id="arr-g" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5" fill="none" stroke="#5a8a5a" stroke-width="1"/>
+    </marker>
+    <marker id="arr-b" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5" fill="none" stroke="#5a7a9a" stroke-width="1"/>
+    </marker>
+  </defs>
+
+  <!-- LEARN pipeline -->
+  <text x="20" y="28" class="pipe-label" fill="#3a7a3a">LEARN</text>
+  <text x="20" y="44" class="label">Content in → structured knowledge out</text>
+
+  <rect x="20" y="58" width="76" height="34" rx="6" fill="#f0f7f0" stroke="#c8dcc8"/>
+  <text x="58" y="80" text-anchor="middle" class="stage">Content</text>
+
+  <line x1="96" y1="75" x2="118" y2="75" stroke="#5a8a5a" stroke-width="1.2" marker-end="url(#arr-g)"/>
+
+  <rect x="120" y="58" width="76" height="34" rx="6" fill="#f0f7f0" stroke="#c8dcc8"/>
+  <text x="158" y="80" text-anchor="middle" class="stage">Parse</text>
+
+  <line x1="196" y1="75" x2="218" y2="75" stroke="#5a8a5a" stroke-width="1.2" marker-end="url(#arr-g)"/>
+
+  <rect x="220" y="58" width="100" height="34" rx="6" fill="#e6f0e6" stroke="#a8c8a8"/>
+  <text x="270" y="80" text-anchor="middle" class="stage">Comprehend</text>
+
+  <line x1="320" y1="75" x2="342" y2="75" stroke="#5a8a5a" stroke-width="1.2" marker-end="url(#arr-g)"/>
+
+  <rect x="344" y="58" width="76" height="34" rx="6" fill="#f0f7f0" stroke="#c8dcc8"/>
+  <text x="382" y="80" text-anchor="middle" class="stage">Extract</text>
+
+  <line x1="420" y1="75" x2="442" y2="75" stroke="#5a8a5a" stroke-width="1.2" marker-end="url(#arr-g)"/>
+
+  <rect x="444" y="58" width="80" height="34" rx="6" fill="#f0f7f0" stroke="#c8dcc8"/>
+  <text x="484" y="80" text-anchor="middle" class="stage">Integrate</text>
+
+  <line x1="524" y1="75" x2="546" y2="75" stroke="#5a8a5a" stroke-width="1.2" marker-end="url(#arr-g)"/>
+
+  <!-- Knowledge Graph (shared) -->
+  <rect x="548" y="58" width="112" height="90" rx="10" fill="#fafaf8" stroke="#2d2d2d" stroke-width="1.5"/>
+  <text x="604" y="84" text-anchor="middle" class="stage">Knowledge</text>
+  <text x="604" y="100" text-anchor="middle" class="stage">Graph</text>
+
+  <!-- Small graph illustration -->
+  <circle cx="578" cy="126" r="4" fill="#c8dcc8" stroke="#5a8a5a"/>
+  <circle cx="604" cy="118" r="4" fill="#c8dcc8" stroke="#5a8a5a"/>
+  <circle cx="630" cy="128" r="4" fill="#c8dcc8" stroke="#5a8a5a"/>
+  <circle cx="604" cy="136" r="4" fill="#c8dcc8" stroke="#5a8a5a"/>
+  <line x1="578" y1="126" x2="604" y2="118" stroke="#5a8a5a" stroke-width="0.8"/>
+  <line x1="604" y1="118" x2="630" y2="128" stroke="#5a8a5a" stroke-width="0.8"/>
+  <line x1="578" y1="126" x2="604" y2="136" stroke="#5a8a5a" stroke-width="0.8"/>
+  <line x1="604" y1="136" x2="630" y2="128" stroke="#5a8a5a" stroke-width="0.8"/>
+
+  <!-- APPLY pipeline -->
+  <text x="20" y="186" class="pipe-label" fill="#3a6a8a">APPLY</text>
+  <text x="20" y="202" class="label">Question in → expert context out</text>
+
+  <rect x="20" y="216" width="76" height="34" rx="6" fill="#eef4f8" stroke="#c0d4e0"/>
+  <text x="58" y="238" text-anchor="middle" class="stage">Query</text>
+
+  <line x1="96" y1="233" x2="118" y2="233" stroke="#5a7a9a" stroke-width="1.2" marker-end="url(#arr-b)"/>
+
+  <rect x="120" y="216" width="90" height="34" rx="6" fill="#eef4f8" stroke="#c0d4e0"/>
+  <text x="165" y="238" text-anchor="middle" class="stage">Understand</text>
+
+  <line x1="210" y1="233" x2="232" y2="233" stroke="#5a7a9a" stroke-width="1.2" marker-end="url(#arr-b)"/>
+
+  <rect x="234" y="216" width="76" height="34" rx="6" fill="#eef4f8" stroke="#c0d4e0"/>
+  <text x="272" y="238" text-anchor="middle" class="stage">Retrieve</text>
+
+  <!-- Arrow up to graph -->
+  <line x1="272" y1="216" x2="272" y2="160" stroke="#5a7a9a" stroke-width="1" stroke-dasharray="4,3"/>
+  <line x1="272" y1="160" x2="548" y2="120" stroke="#5a7a9a" stroke-width="1" stroke-dasharray="4,3"/>
+
+  <line x1="310" y1="233" x2="332" y2="233" stroke="#5a7a9a" stroke-width="1.2" marker-end="url(#arr-b)"/>
+
+  <rect x="334" y="216" width="76" height="34" rx="6" fill="#eef4f8" stroke="#c0d4e0"/>
+  <text x="372" y="238" text-anchor="middle" class="stage">Traverse</text>
+
+  <line x1="410" y1="233" x2="432" y2="233" stroke="#5a7a9a" stroke-width="1.2" marker-end="url(#arr-b)"/>
+
+  <rect x="434" y="216" width="76" height="34" rx="6" fill="#e4ecf2" stroke="#a0b8cc"/>
+  <text x="472" y="232" text-anchor="middle" class="stage" style="font-size:10px">Detect</text>
+  <text x="472" y="244" text-anchor="middle" class="stage" style="font-size:10px">Gaps</text>
+
+  <line x1="510" y1="233" x2="532" y2="233" stroke="#5a7a9a" stroke-width="1.2" marker-end="url(#arr-b)"/>
+
+  <rect x="534" y="216" width="76" height="34" rx="6" fill="#eef4f8" stroke="#c0d4e0"/>
+  <text x="572" y="238" text-anchor="middle" class="stage">Compose</text>
+
+  <line x1="610" y1="233" x2="632" y2="233" stroke="#5a7a9a" stroke-width="1.2" marker-end="url(#arr-b)"/>
+
+  <!-- Output -->
+  <rect x="634" y="216" width="34" height="34" rx="6" fill="#eef4f8" stroke="#3a6a8a" stroke-width="1.5"/>
+  <text x="651" y="237" text-anchor="middle" class="label" style="font-size:16px;">📦</text>
+
+  <!-- Bottom note -->
+  <text x="340" y="285" text-anchor="middle" class="label">Both pipelines use LLMs as internal components.</text>
+  <text x="340" y="298" text-anchor="middle" class="label">The LLM is a tool within Metis, not the product.</text>
+</svg>

--- a/site/src/content/log/001-foundations.md
+++ b/site/src/content/log/001-foundations.md
@@ -34,6 +34,8 @@ We stress-tested this against two dense chapters from an industry analysis textb
 
 ## The linguistic insight
 
+![Triple vs micro-frame — why two roles aren't enough](/images/log/triple-vs-frame.svg)
+
 Charles Fillmore's **Frame Semantics** provided the breakthrough. Fillmore argued that meaning is organized in *frames* — structured situations with defined *roles*. The word "buy" evokes a Commercial Transaction frame with roles: Buyer, Seller, Goods, Money.
 
 Our triple was forcing everything into two roles (subject, object). Many knowledge structures naturally have three, four, or more roles.
@@ -56,6 +58,8 @@ Atom {
 ```
 
 Simple binary relations are just frames with two roles — nothing is lost. But a demand evaluation matrix naturally becomes one atom with four roles instead of four awkward triples.
+
+![The atom — a deviation frame from the stress test](/images/log/atom-structure.svg)
 
 ## Stress test results
 

--- a/site/src/content/log/002-architecture.md
+++ b/site/src/content/log/002-architecture.md
@@ -8,6 +8,8 @@ Second design session. We moved from "what is the atom" to "how does the system 
 
 ## Two pipelines
 
+![Learn and Apply — two pipelines sharing one knowledge graph](/images/log/two-pipelines.svg)
+
 Metis has two sides, and each is a pipeline:
 
 **Learn:** Content → Parse → Comprehend → Extract → Integrate → Knowledge Graph
@@ -15,6 +17,8 @@ Metis has two sides, and each is a pipeline:
 **Apply:** Query → Understand → Retrieve → Traverse → Detect Gaps → Compose → Context Package
 
 Both use LLMs as internal components. But the LLM is a tool *within* Metis, not the product. The product is the structured knowledge and the context packages it produces.
+
+![Cost split — 1 expensive comprehension call guides N cheap extraction calls](/images/log/cost-split.svg)
 
 ## The cost question
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -247,6 +247,13 @@ li {
   margin-top: 0;
 }
 
+.post-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: var(--spacing-unit);
+}
+
 /* Section divider */
 
 .section {


### PR DESCRIPTION
## Summary
- 4 SVG diagrams added to `site/public/images/log/`
- Article 1 (Foundations): triple vs frame comparison, atom structure example
- Article 2 (Architecture): two-pipeline flow, cost split visualization
- Image CSS added to constrain width and style consistently

## Why
The articles describe abstract concepts (frames, pipelines, cost models) that are much easier to grasp visually.

## How to test
```bash
cd site && npm install && npm run dev
```
- Visit `/log/001-foundations` — diagrams after "The linguistic insight" and before "Stress test results"
- Visit `/log/002-architecture` — diagrams after "Two pipelines" heading and before "The cost question"
- SVGs should scale cleanly and respect dark mode text

## Migration steps
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)