### PR TITLE
feat: add retrieval engine, eval framework, and checkpoint recovery

### DIFF
--- a/engine/src/checkpoint.ts
+++ b/engine/src/checkpoint.ts
@@ -1,0 +1,174 @@
+/**
+ * Checkpoint manager — save and resume pipeline state between stages.
+ *
+ * Each book gets its own checkpoint directory under {graphDir}/.checkpoints/{slug}/.
+ * Stage outputs are saved as JSON. A meta.json tracks stage statuses, timing,
+ * and pipeline config so --resume knows where to pick up.
+ */
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const STAGE_ORDER = ["parse", "comprehend", "extract", "integrate"] as const;
+type StageName = (typeof STAGE_ORDER)[number];
+
+export type StageStatus =
+	| { status: "pending" }
+	| { status: "completed"; completedAt: string; durationMs: number }
+	| { status: "failed"; error: string; failedAt: string };
+
+export interface CheckpointMeta {
+	bookSlug: string;
+	startedAt: string;
+	stages: Record<string, StageStatus>;
+	config: Record<string, string>;
+}
+
+export interface CheckpointManager {
+	save(stage: string, data: unknown): void;
+	load<T>(stage: string): T | null;
+	getMeta(): CheckpointMeta | null;
+	updateStage(stage: string, status: StageStatus): void;
+	setConfig(config: Record<string, string>): void;
+	getResumePoint(): string | null;
+	clear(): void;
+}
+
+function ensureDir(dir: string) {
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+}
+
+export function createCheckpointManager(
+	bookSlug: string,
+	graphDir: string,
+): CheckpointManager {
+	const checkpointDir = join(graphDir, bookSlug);
+	const metaPath = join(checkpointDir, "meta.json");
+
+	function readMeta(): CheckpointMeta | null {
+		if (!existsSync(metaPath)) return null;
+		try {
+			return JSON.parse(readFileSync(metaPath, "utf8")) as CheckpointMeta;
+		} catch {
+			return null;
+		}
+	}
+
+	function writeMeta(meta: CheckpointMeta) {
+		ensureDir(checkpointDir);
+		writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+	}
+
+	function getOrCreateMeta(): CheckpointMeta {
+		const existing = readMeta();
+		if (existing) return existing;
+		const fresh: CheckpointMeta = {
+			bookSlug,
+			startedAt: new Date().toISOString(),
+			stages: {},
+			config: {},
+		};
+		for (const stage of STAGE_ORDER) {
+			fresh.stages[stage] = { status: "pending" };
+		}
+		return fresh;
+	}
+
+	return {
+		save(stage: string, data: unknown) {
+			ensureDir(checkpointDir);
+			const filePath = join(checkpointDir, `${stage}.json`);
+			writeFileSync(filePath, JSON.stringify(data));
+		},
+
+		load<T>(stage: string): T | null {
+			const filePath = join(checkpointDir, `${stage}.json`);
+			if (!existsSync(filePath)) return null;
+			try {
+				return JSON.parse(readFileSync(filePath, "utf8")) as T;
+			} catch {
+				return null;
+			}
+		},
+
+		getMeta(): CheckpointMeta | null {
+			return readMeta();
+		},
+
+		updateStage(stage: string, status: StageStatus) {
+			const meta = getOrCreateMeta();
+			meta.stages[stage] = status;
+			writeMeta(meta);
+		},
+
+		setConfig(config: Record<string, string>) {
+			const meta = getOrCreateMeta();
+			meta.config = { ...meta.config, ...config };
+			writeMeta(meta);
+		},
+
+		getResumePoint(): string | null {
+			const meta = readMeta();
+			if (!meta) return null;
+			for (const stage of STAGE_ORDER) {
+				const status = meta.stages[stage];
+				if (!status || status.status !== "completed") {
+					return stage;
+				}
+			}
+			return null; // all completed
+		},
+
+		clear() {
+			if (existsSync(checkpointDir)) {
+				rmSync(checkpointDir, { recursive: true });
+			}
+		},
+	};
+}
+
+/**
+ * Format checkpoint status for display.
+ */
+export function formatCheckpointStatus(meta: CheckpointMeta): string {
+	const lines: string[] = [];
+	lines.push(`Checkpoint: ${meta.bookSlug}`);
+	lines.push(`Started: ${meta.startedAt}`);
+
+	if (Object.keys(meta.config).length > 0) {
+		const provider = meta.config.comprehendProvider ?? "unknown";
+		const model = meta.config.comprehendModel ?? "unknown";
+		lines.push(`Config: ${provider}/${model}`);
+	}
+
+	lines.push("");
+
+	for (const stage of STAGE_ORDER) {
+		const status = meta.stages[stage];
+		if (!status || status.status === "pending") {
+			lines.push(`  ${stage.padEnd(14)} · pending`);
+		} else if (status.status === "completed") {
+			const duration = formatDuration(status.durationMs);
+			lines.push(`  ${stage.padEnd(14)} ✓ completed (${duration})`);
+		} else if (status.status === "failed") {
+			lines.push(`  ${stage.padEnd(14)} ✗ failed — "${status.error}"`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+	const minutes = Math.floor(ms / 60000);
+	const seconds = Math.round((ms % 60000) / 1000);
+	return `${minutes}m ${seconds}s`;
+}

--- a/engine/src/eval/checks.ts
+++ b/engine/src/eval/checks.ts
@@ -1,0 +1,233 @@
+/**
+ * Evaluation checks — three layers of atom quality validation.
+ *
+ * Structural: hard rejects (missing frame, empty roles, unregistered type)
+ * Schema: soft flags (missing required/optional roles for the frame type)
+ * Semantic: soft flags (compound values, vague content, confidence outliers)
+ *
+ * The structural and schema checks wrap logic from extract/atom-validator.ts
+ * but expose each check individually for reporting. The semantic checks are
+ * new — they catch issues the validator doesn't.
+ */
+import type { CandidateAtom, FrameTypeRegistry } from "../extract/types";
+
+export interface EvalResult {
+	pass: boolean;
+	detail?: string;
+}
+
+export interface EvalCheck {
+	id: string;
+	name: string;
+	layer: "structural" | "schema" | "semantic";
+	severity: "reject" | "flag";
+	run: (atom: CandidateAtom, context?: CheckContext) => EvalResult;
+}
+
+export interface CheckContext {
+	registry?: FrameTypeRegistry;
+	frameStats?: Map<string, { meanConfidence: number; stdConfidence: number }>;
+}
+
+// --- Vague content patterns ---
+
+const VAGUE_PATTERNS = [
+	/^various\s/i,
+	/^important\s/i,
+	/^significant\s/i,
+	/^relevant\s/i,
+	/^different\s/i,
+	/^several\s/i,
+	/^many\s/i,
+	/^some\s/i,
+];
+
+const VAGUE_EXACT = new Set([
+	"important",
+	"significant",
+	"relevant",
+	"concept",
+	"thing",
+	"stuff",
+	"various",
+	"etc",
+	"others",
+]);
+
+function isVague(value: string): boolean {
+	if (value.length < 10) return true;
+	const lower = value.toLowerCase().trim();
+	if (VAGUE_EXACT.has(lower)) return true;
+	return VAGUE_PATTERNS.some((p) => p.test(lower));
+}
+
+/** Count sentences by splitting on period/exclamation/question followed by space or end. */
+function countSentences(text: string): number {
+	const sentences = text
+		.split(/[.!?。！？]\s+|[.!?。！？]$/)
+		.filter((s) => s.trim().length > 0);
+	return sentences.length;
+}
+
+// --- Check definitions ---
+
+export const CHECKS: EvalCheck[] = [
+	// Structural
+	{
+		id: "structural:missing-frame",
+		name: "Missing frame type",
+		layer: "structural",
+		severity: "reject",
+		run: (atom) => ({
+			pass: Boolean(atom.frame && atom.frame.trim().length > 0),
+			detail: atom.frame ? undefined : "atom has no frame type",
+		}),
+	},
+	{
+		id: "structural:empty-roles",
+		name: "Empty roles",
+		layer: "structural",
+		severity: "reject",
+		run: (atom) => ({
+			pass: Object.keys(atom.roles).length > 0,
+			detail:
+				Object.keys(atom.roles).length === 0
+					? "atom has zero roles"
+					: undefined,
+		}),
+	},
+	{
+		id: "structural:unregistered-frame",
+		name: "Unregistered frame type",
+		layer: "structural",
+		severity: "reject",
+		run: (atom, ctx) => {
+			if (!ctx?.registry) return { pass: true }; // skip if no registry
+			return {
+				pass: ctx.registry.has(atom.frame),
+				detail: ctx.registry.has(atom.frame)
+					? undefined
+					: `frame "${atom.frame}" not in registry`,
+			};
+		},
+	},
+
+	// Schema
+	{
+		id: "schema:missing-required-role",
+		name: "Missing required role",
+		layer: "schema",
+		severity: "flag",
+		run: (atom, ctx) => {
+			if (!ctx?.registry) return { pass: true };
+			const frameType = ctx.registry.get(atom.frame);
+			if (!frameType) return { pass: true }; // unregistered frame handled elsewhere
+			const missing = frameType.requiredRoles.filter((r) => !atom.roles[r]);
+			return {
+				pass: missing.length === 0,
+				detail:
+					missing.length > 0
+						? `missing required: ${missing.join(", ")}`
+						: undefined,
+			};
+		},
+	},
+	{
+		id: "schema:missing-optional-role",
+		name: "Missing optional role",
+		layer: "schema",
+		severity: "flag",
+		run: (atom, ctx) => {
+			if (!ctx?.registry) return { pass: true };
+			const frameType = ctx.registry.get(atom.frame);
+			if (!frameType) return { pass: true };
+			const allRoles = Object.keys(frameType.roles);
+			const optional = allRoles.filter(
+				(r) => !frameType.requiredRoles.includes(r) && !atom.roles[r],
+			);
+			return {
+				pass: optional.length === 0,
+				detail:
+					optional.length > 0
+						? `missing optional: ${optional.join(", ")}`
+						: undefined,
+			};
+		},
+	},
+
+	// Semantic
+	{
+		id: "semantic:compound-role",
+		name: "Compound role value",
+		layer: "semantic",
+		severity: "flag",
+		run: (atom) => {
+			for (const [role, rawValue] of Object.entries(atom.roles)) {
+				const value =
+					typeof rawValue === "string" ? rawValue : String(rawValue ?? "");
+				// Skip short values — can't be compound
+				if (value.length < 30) continue;
+				if (countSentences(value) >= 3) {
+					return {
+						pass: false,
+						detail: `role "${role}" has ${countSentences(value)} sentences (expected 1-2)`,
+					};
+				}
+			}
+			return { pass: true };
+		},
+	},
+	{
+		id: "semantic:vague-content",
+		name: "Vague or generic content",
+		layer: "semantic",
+		severity: "flag",
+		run: (atom) => {
+			for (const [role, rawValue] of Object.entries(atom.roles)) {
+				const value =
+					typeof rawValue === "string" ? rawValue : String(rawValue ?? "");
+				if (isVague(value)) {
+					return {
+						pass: false,
+						detail: `role "${role}" is vague: "${value.slice(0, 40)}"`,
+					};
+				}
+			}
+			return { pass: true };
+		},
+	},
+	{
+		id: "semantic:confidence-outlier",
+		name: "Confidence outlier",
+		layer: "semantic",
+		severity: "flag",
+		run: (atom, ctx) => {
+			if (!ctx?.frameStats) return { pass: true };
+			const stats = ctx.frameStats.get(atom.frame);
+			if (!stats) return { pass: true };
+			const deviation = Math.abs(atom.confidence - stats.meanConfidence);
+			const sigmas =
+				stats.stdConfidence > 0 ? deviation / stats.stdConfidence : 0;
+			return {
+				pass: sigmas <= 2,
+				detail:
+					sigmas > 2
+						? `confidence ${atom.confidence.toFixed(2)} is ${sigmas.toFixed(1)}σ from frame mean ${stats.meanConfidence.toFixed(2)}`
+						: undefined,
+			};
+		},
+	},
+	{
+		id: "semantic:empty-conditions",
+		name: "No conditions specified",
+		layer: "semantic",
+		severity: "flag",
+		run: (atom) => ({
+			pass: atom.conditions.length > 0,
+			detail:
+				atom.conditions.length === 0
+					? "atom has no conditions (contextless knowledge)"
+					: undefined,
+		}),
+	},
+];

--- a/engine/src/eval/comparison.ts
+++ b/engine/src/eval/comparison.ts
@@ -1,0 +1,61 @@
+/**
+ * Comparison mode — compute the delta between two eval reports.
+ *
+ * Used to show "before validation" vs "after validation" reduction
+ * in issue rates. This is the core of the "40% → <2%" resume claim.
+ */
+import type { EvalReport } from "./runner";
+
+export interface ComparisonReport {
+	before: { source: string; atomCount: number; issueRate: number };
+	after: { source: string; atomCount: number; issueRate: number };
+	/** Percentage reduction in issue rate (e.g., 94.7 means 94.7% reduction) */
+	reductionPct: number;
+	perCheck: Array<{
+		check: string;
+		beforeRate: number;
+		afterRate: number;
+	}>;
+}
+
+export function compareReports(
+	before: EvalReport,
+	after: EvalReport,
+): ComparisonReport {
+	// Per-check deltas for checks present in both reports
+	const afterMap = new Map(after.checks.map((c) => [c.check, c]));
+	const perCheck: ComparisonReport["perCheck"] = [];
+
+	for (const bc of before.checks) {
+		const ac = afterMap.get(bc.check);
+		if (ac) {
+			perCheck.push({
+				check: bc.check,
+				beforeRate: bc.rate,
+				afterRate: ac.rate,
+			});
+		}
+	}
+
+	const reductionPct =
+		before.aggregate.issueRate > 0
+			? ((before.aggregate.issueRate - after.aggregate.issueRate) /
+					before.aggregate.issueRate) *
+				100
+			: 0;
+
+	return {
+		before: {
+			source: before.source,
+			atomCount: before.atomCount,
+			issueRate: before.aggregate.issueRate,
+		},
+		after: {
+			source: after.source,
+			atomCount: after.atomCount,
+			issueRate: after.aggregate.issueRate,
+		},
+		reductionPct,
+		perCheck,
+	};
+}

--- a/engine/src/eval/runner.ts
+++ b/engine/src/eval/runner.ts
@@ -1,0 +1,129 @@
+/**
+ * Eval runner — batch atoms through all checks, produce a structured report.
+ *
+ * Computes per-check pass/fail tallies and an aggregate "atoms with issues"
+ * count. The aggregate counts each atom once even if it fails multiple checks.
+ */
+import type { CandidateAtom, FrameTypeRegistry } from "../extract/types";
+import { CHECKS, type CheckContext } from "./checks";
+
+export interface CheckResult {
+	check: string;
+	layer: string;
+	severity: string;
+	pass: number;
+	fail: number;
+	rate: number;
+	samples: string[];
+}
+
+export interface EvalReport {
+	source: string;
+	atomCount: number;
+	checks: CheckResult[];
+	aggregate: {
+		atomsWithIssues: number;
+		issueRate: number;
+	};
+}
+
+export interface RunEvalOptions {
+	registry?: FrameTypeRegistry;
+	checks?: string[];
+	source?: string;
+}
+
+/**
+ * Compute per-frame-type confidence stats for the semantic:confidence-outlier check.
+ */
+function computeFrameStats(
+	atoms: CandidateAtom[],
+): Map<string, { meanConfidence: number; stdConfidence: number }> {
+	const byFrame = new Map<string, number[]>();
+	for (const atom of atoms) {
+		const list = byFrame.get(atom.frame) ?? [];
+		list.push(atom.confidence);
+		byFrame.set(atom.frame, list);
+	}
+
+	const stats = new Map<
+		string,
+		{ meanConfidence: number; stdConfidence: number }
+	>();
+	for (const [frame, confidences] of byFrame) {
+		const mean = confidences.reduce((s, c) => s + c, 0) / confidences.length;
+		const variance =
+			confidences.reduce((s, c) => s + (c - mean) ** 2, 0) / confidences.length;
+		stats.set(frame, {
+			meanConfidence: mean,
+			stdConfidence: Math.sqrt(variance),
+		});
+	}
+	return stats;
+}
+
+/**
+ * Run evaluation checks against a batch of atoms.
+ */
+export function runEval(
+	atoms: CandidateAtom[],
+	options?: RunEvalOptions,
+): EvalReport {
+	const frameStats = computeFrameStats(atoms);
+	const ctx: CheckContext = {
+		registry: options?.registry,
+		frameStats,
+	};
+
+	// Filter checks if specific ones requested
+	const activeChecks = options?.checks
+		? CHECKS.filter((c) => options.checks?.includes(c.id))
+		: CHECKS;
+
+	// Per-check tallies
+	const tallies = activeChecks.map((check) => ({
+		check: check.id,
+		layer: check.layer,
+		severity: check.severity,
+		pass: 0,
+		fail: 0,
+		samples: [] as string[],
+	}));
+
+	// Track which atoms have any issue (for aggregate)
+	const atomsWithIssues = new Set<string>();
+
+	for (const atom of atoms) {
+		for (let i = 0; i < activeChecks.length; i++) {
+			const check = activeChecks[i];
+			const tally = tallies[i];
+			if (!check || !tally) continue;
+
+			const result = check.run(atom, ctx);
+			if (result.pass) {
+				tally.pass++;
+			} else {
+				tally.fail++;
+				atomsWithIssues.add(atom.id);
+				if (tally.samples.length < 3) {
+					tally.samples.push(atom.id);
+				}
+			}
+		}
+	}
+
+	const checkResults: CheckResult[] = tallies.map((t) => ({
+		...t,
+		rate: atoms.length > 0 ? t.fail / atoms.length : 0,
+	}));
+
+	return {
+		source: options?.source ?? "inline",
+		atomCount: atoms.length,
+		checks: checkResults,
+		aggregate: {
+			atomsWithIssues: atomsWithIssues.size,
+			issueRate: atoms.length > 0 ? atomsWithIssues.size / atoms.length : 0,
+		},
+	};
+}

--- a/engine/src/retrieve/bm25.ts
+++ b/engine/src/retrieve/bm25.ts
@@ -1,0 +1,128 @@
+/**
+ * BM25 (Best Matching 25) index and scoring.
+ *
+ * BM25 is a bag-of-words ranking function that scores documents by how well
+ * their terms match the query. It improves on raw TF-IDF by adding term
+ * frequency saturation (k1) and document length normalization (b).
+ *
+ * Formula:
+ *   score(D, Q) = Σ IDF(qi) · (tf(qi,D) · (k1+1)) / (tf(qi,D) + k1 · (1 - b + b · |D|/avgdl))
+ *
+ * Where:
+ *   IDF(qi) = ln((N - n(qi) + 0.5) / (n(qi) + 0.5) + 1)
+ *   N = total documents, n(qi) = documents containing term qi
+ */
+import { tokenize, tokenizeWithFrequency } from "./tokenizer";
+
+export interface BM25Index {
+	/** Inverted index: term → list of (docIndex, termFrequency) */
+	invertedIndex: Map<string, Array<{ doc: number; tf: number }>>;
+	/** Document IDs in index order */
+	docIds: string[];
+	/** Token count per document */
+	docLengths: number[];
+	/** Average document length */
+	avgDocLength: number;
+	/** Total number of documents */
+	docCount: number;
+	/** Pre-computed IDF: term → inverse document frequency */
+	idf: Map<string, number>;
+}
+
+/** BM25 tuning parameters */
+const K1 = 1.5; // term frequency saturation
+const B = 0.75; // document length normalization
+
+/**
+ * Build a BM25 index from an array of documents.
+ */
+export function buildBM25Index(
+	docs: Array<{ id: string; text: string }>,
+): BM25Index {
+	const docIds: string[] = [];
+	const docLengths: number[] = [];
+	const invertedIndex = new Map<string, Array<{ doc: number; tf: number }>>();
+
+	// Index each document
+	for (let i = 0; i < docs.length; i++) {
+		const doc = docs[i];
+		if (!doc) continue;
+		docIds.push(doc.id);
+
+		const freq = tokenizeWithFrequency(doc.text);
+		let docLength = 0;
+		for (const count of freq.values()) {
+			docLength += count;
+		}
+		docLengths.push(docLength);
+
+		// Build inverted index
+		for (const [term, tf] of freq) {
+			let postings = invertedIndex.get(term);
+			if (!postings) {
+				postings = [];
+				invertedIndex.set(term, postings);
+			}
+			postings.push({ doc: i, tf });
+		}
+	}
+
+	const docCount = docs.length;
+	const totalLength = docLengths.reduce((sum, l) => sum + l, 0);
+	const avgDocLength = docCount > 0 ? totalLength / docCount : 0;
+
+	// Pre-compute IDF for all terms
+	const idf = new Map<string, number>();
+	for (const [term, postings] of invertedIndex) {
+		const n = postings.length; // number of docs containing term
+		// BM25 IDF with +1 to avoid negative values for very common terms
+		const idfValue = Math.log((docCount - n + 0.5) / (n + 0.5) + 1);
+		idf.set(term, idfValue);
+	}
+
+	return { invertedIndex, docIds, docLengths, avgDocLength, docCount, idf };
+}
+
+/**
+ * Score documents against a query using BM25.
+ * Returns top-k results sorted by descending score.
+ */
+export function queryBM25(
+	index: BM25Index,
+	query: string,
+	topK: number,
+): Array<{ id: string; score: number }> {
+	const queryTerms = tokenize(query);
+	if (queryTerms.length === 0) return [];
+
+	// Accumulate scores per document
+	const scores = new Float64Array(index.docCount);
+
+	for (const term of queryTerms) {
+		const termIdf = index.idf.get(term);
+		if (termIdf === undefined) continue; // term not in corpus
+
+		const postings = index.invertedIndex.get(term);
+		if (!postings) continue;
+
+		for (const { doc, tf } of postings) {
+			const dl = index.docLengths[doc] ?? 0;
+			const numerator = tf * (K1 + 1);
+			const denominator = tf + K1 * (1 - B + B * (dl / index.avgDocLength));
+			scores[doc] += termIdf * (numerator / denominator);
+		}
+	}
+
+	// Collect non-zero scores and sort
+	const results: Array<{ id: string; score: number }> = [];
+	for (let i = 0; i < scores.length; i++) {
+		const score = scores[i] ?? 0;
+		const docId = index.docIds[i];
+		if (score > 0 && docId) {
+			results.push({ id: docId, score });
+		}
+	}
+
+	results.sort((a, b) => b.score - a.score);
+	return results.slice(0, topK);
+}

--- a/engine/src/retrieve/hybrid.ts
+++ b/engine/src/retrieve/hybrid.ts
@@ -1,0 +1,74 @@
+/**
+ * Reciprocal Rank Fusion (RRF) for combining multiple retrieval methods.
+ *
+ * RRF merges ranked lists without needing score normalization. Each method
+ * contributes 1/(k + rank) per item, where k is a constant (default 60)
+ * that prevents high-ranked items from dominating.
+ *
+ * Reference: Cormack, Clarke & Buettcher (2009)
+ *   "Reciprocal Rank Fusion outperforms Condorcet and individual
+ *    Rank Learning Methods"
+ */
+
+export interface RankedList {
+	method: string;
+	results: Array<{ id: string; score: number }>;
+}
+
+export interface FusedResult {
+	id: string;
+	score: number;
+	ranks: Record<string, number | null>;
+}
+
+/**
+ * Fuse multiple ranked lists into a single ranked result using RRF.
+ *
+ * @param ranked - Ranked lists from different retrieval methods
+ * @param topK - Maximum number of results to return
+ * @param k - RRF constant (default 60)
+ */
+export function fuseResults(
+	ranked: RankedList[],
+	topK: number,
+	k = 60,
+): FusedResult[] {
+	if (ranked.length === 0) return [];
+
+	// Accumulate RRF scores and track per-method ranks
+	const scoreMap = new Map<
+		string,
+		{ score: number; ranks: Record<string, number | null> }
+	>();
+
+	// Initialize all method names for rank tracking
+	const methodNames = ranked.map((r) => r.method);
+
+	for (const list of ranked) {
+		for (let rank = 0; rank < list.results.length; rank++) {
+			const item = list.results[rank];
+			if (!item) continue;
+			const rrfScore = 1 / (k + rank + 1); // rank is 0-based, +1 to make 1-based
+
+			let entry = scoreMap.get(item.id);
+			if (!entry) {
+				const ranks: Record<string, number | null> = {};
+				for (const m of methodNames) ranks[m] = null;
+				entry = { score: 0, ranks };
+				scoreMap.set(item.id, entry);
+			}
+
+			entry.score += rrfScore;
+			entry.ranks[list.method] = rank + 1; // 1-based rank
+		}
+	}
+
+	// Sort by fused score descending
+	const results: FusedResult[] = [];
+	for (const [id, entry] of scoreMap) {
+		results.push({ id, score: entry.score, ranks: entry.ranks });
+	}
+
+	results.sort((a, b) => b.score - a.score);
+	return results.slice(0, topK);
+}

--- a/engine/src/retrieve/index.ts
+++ b/engine/src/retrieve/index.ts
@@ -1,0 +1,121 @@
+/**
+ * Retrieval orchestrator — loads atoms, runs BM25 and/or vector search,
+ * fuses results, and returns ranked atoms.
+ *
+ * Can be called programmatically with pre-loaded data (for tests) or
+ * pointed at a graph directory (for CLI use).
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CandidateAtom } from "../extract/types";
+import { atomToText } from "../integrate/embedding-service";
+import type { Atom } from "../integrate/types";
+import type { VectorIndex } from "../integrate/types";
+import { buildBM25Index, queryBM25 } from "./bm25";
+import { type FusedResult, fuseResults } from "./hybrid";
+import { queryVectors } from "./vector-search";
+
+export interface RetrievalResult {
+	atom: CandidateAtom;
+	score: number;
+	ranks: Record<string, number | null>;
+}
+
+export interface RetrieveOptions {
+	query: string;
+	topK?: number;
+	method?: "hybrid" | "bm25" | "vector";
+	/** Pre-loaded atoms (skips file I/O) */
+	atoms?: CandidateAtom[];
+	/** Pre-loaded embeddings (skips file I/O) */
+	embeddings?: VectorIndex;
+	/** Pre-computed query embedding (skips API call) */
+	queryEmbedding?: number[];
+	/** Graph directory to load from (ignored if atoms/embeddings provided) */
+	graphDir?: string;
+}
+
+/**
+ * Retrieve the most relevant atoms for a query.
+ */
+export async function retrieve(
+	options: RetrieveOptions,
+): Promise<RetrievalResult[]> {
+	const {
+		query,
+		topK = 10,
+		method = "hybrid",
+		queryEmbedding,
+		graphDir,
+	} = options;
+
+	// Load data from files if not provided
+	const atoms =
+		options.atoms ??
+		loadJson<CandidateAtom[]>(graphDir ?? "graph", "atoms.json");
+	const atomMap = new Map(atoms.map((a) => [a.id, a]));
+
+	// Candidate pool size — retrieve more than topK per method so fusion has
+	// enough candidates to work with
+	const poolSize = Math.min(topK * 3, atoms.length);
+
+	const rankedLists: Array<{
+		method: string;
+		results: Array<{ id: string; score: number }>;
+	}> = [];
+
+	// BM25
+	if (method === "bm25" || method === "hybrid") {
+		const docs = atoms.map((a) => ({ id: a.id, text: atomToText(a) }));
+		const index = buildBM25Index(docs);
+		const bm25Results = queryBM25(index, query, poolSize);
+		rankedLists.push({ method: "bm25", results: bm25Results });
+	}
+
+	// Vector
+	if (method === "vector" || method === "hybrid") {
+		const embeddings =
+			options.embeddings ??
+			loadJsonSafe<VectorIndex>(graphDir ?? "graph", "embeddings.json");
+
+		if (embeddings && embeddings.length > 0 && queryEmbedding) {
+			const vectorResults = queryVectors(queryEmbedding, embeddings, poolSize);
+			rankedLists.push({ method: "vector", results: vectorResults });
+		} else if (method === "vector") {
+			// Vector-only mode but no embeddings — return empty
+			return [];
+		}
+		// hybrid mode without embeddings: silently fall back to BM25-only
+	}
+
+	// Fuse
+	const fused = fuseResults(rankedLists, topK);
+
+	// Map back to atoms
+	return fused
+		.map((f) => {
+			const atom = atomMap.get(f.id);
+			if (!atom) return null;
+			return {
+				atom,
+				score: f.score,
+				ranks: {
+					bm25: f.ranks.bm25 ?? null,
+					vector: f.ranks.vector ?? null,
+				},
+			};
+		})
+		.filter((r): r is RetrievalResult => r !== null);
+}
+
+function loadJson<T>(dir: string, file: string): T {
+	return JSON.parse(readFileSync(join(dir, file), "utf8")) as T;
+}
+
+function loadJsonSafe<T>(dir: string, file: string): T | null {
+	try {
+		return JSON.parse(readFileSync(join(dir, file), "utf8")) as T;
+	} catch {
+		return null;
+	}
+}

--- a/engine/src/retrieve/tokenizer.ts
+++ b/engine/src/retrieve/tokenizer.ts
@@ -1,0 +1,183 @@
+/**
+ * Text tokenizer for BM25 retrieval.
+ *
+ * Handles English (whitespace split + stopwords) and CJK (character bigrams).
+ * CJK languages don't use whitespace between words, so we use overlapping
+ * bigrams as a simple segmentation strategy that works without external
+ * dictionaries. This is standard practice in CJK information retrieval.
+ */
+
+const STOPWORDS = new Set([
+	"a",
+	"an",
+	"the",
+	"is",
+	"are",
+	"was",
+	"were",
+	"be",
+	"been",
+	"being",
+	"have",
+	"has",
+	"had",
+	"do",
+	"does",
+	"did",
+	"will",
+	"would",
+	"could",
+	"should",
+	"may",
+	"might",
+	"shall",
+	"can",
+	"need",
+	"dare",
+	"ought",
+	"and",
+	"or",
+	"but",
+	"nor",
+	"not",
+	"so",
+	"yet",
+	"both",
+	"either",
+	"neither",
+	"each",
+	"every",
+	"all",
+	"any",
+	"few",
+	"more",
+	"most",
+	"other",
+	"some",
+	"such",
+	"no",
+	"only",
+	"own",
+	"same",
+	"than",
+	"too",
+	"very",
+	"just",
+	"because",
+	"as",
+	"until",
+	"while",
+	"of",
+	"at",
+	"by",
+	"for",
+	"with",
+	"about",
+	"against",
+	"between",
+	"through",
+	"during",
+	"before",
+	"after",
+	"above",
+	"below",
+	"to",
+	"from",
+	"up",
+	"down",
+	"in",
+	"out",
+	"on",
+	"off",
+	"over",
+	"under",
+	"again",
+	"further",
+	"then",
+	"once",
+	"here",
+	"there",
+	"when",
+	"where",
+	"why",
+	"how",
+	"that",
+	"this",
+	"these",
+	"those",
+	"it",
+	"its",
+	"i",
+	"me",
+	"my",
+	"we",
+	"our",
+	"you",
+	"your",
+	"he",
+	"him",
+	"his",
+	"she",
+	"her",
+	"they",
+	"them",
+	"their",
+	"what",
+	"which",
+	"who",
+	"whom",
+]);
+
+// CJK Unified Ideographs range
+const CJK_REGEX = /[\u4e00-\u9fff]/;
+const CJK_RUN_REGEX = /[\u4e00-\u9fff]+/g;
+const NON_ALNUM_REGEX = /[^a-z0-9\u4e00-\u9fff]+/;
+
+/**
+ * Tokenize text into an array of terms (with duplicates).
+ * English: lowercase, split, filter stopwords.
+ * CJK: overlapping character bigrams.
+ */
+export function tokenize(text: string): string[] {
+	if (!text) return [];
+
+	const lower = text.toLowerCase();
+	const tokens: string[] = [];
+
+	// Extract CJK runs and convert to bigrams
+	const cjkRuns = lower.match(CJK_RUN_REGEX);
+	if (cjkRuns) {
+		for (const run of cjkRuns) {
+			if (run.length === 1) {
+				tokens.push(run);
+			} else {
+				for (let i = 0; i < run.length - 1; i++) {
+					tokens.push(run.slice(i, i + 2));
+				}
+			}
+		}
+	}
+
+	// Extract non-CJK tokens (English words, numbers)
+	const withoutCjk = lower.replace(CJK_RUN_REGEX, " ");
+	const words = withoutCjk.split(NON_ALNUM_REGEX).filter(Boolean);
+	for (const word of words) {
+		if (!STOPWORDS.has(word) && !CJK_REGEX.test(word)) {
+			tokens.push(word);
+		}
+	}
+
+	return tokens;
+}
+
+/**
+ * Tokenize and return a frequency map (term → count).
+ */
+export function tokenizeWithFrequency(text: string): Map<string, number> {
+	const tokens = tokenize(text);
+	const freq = new Map<string, number>();
+	for (const token of tokens) {
+		freq.set(token, (freq.get(token) ?? 0) + 1);
+	}
+	return freq;
+}

--- a/engine/src/retrieve/vector-search.ts
+++ b/engine/src/retrieve/vector-search.ts
@@ -1,0 +1,30 @@
+/**
+ * Vector similarity search over pre-computed atom embeddings.
+ *
+ * Reuses cosineSimilarity from the Integrate stage's embedding service.
+ * This is a brute-force linear scan — fine for our ~4K atom dataset.
+ * For 100K+ atoms you'd want an approximate nearest neighbor index (HNSW).
+ */
+import { cosineSimilarity } from "../integrate/embedding-service";
+import type { VectorIndex } from "../integrate/types";
+
+/**
+ * Find the top-k most similar atoms to a query embedding.
+ */
+export function queryVectors(
+	queryEmbedding: number[],
+	index: VectorIndex,
+	topK: number,
+): Array<{ id: string; score: number }> {
+	if (index.length === 0) return [];
+
+	const scored: Array<{ id: string; score: number }> = [];
+
+	for (const entry of index) {
+		const score = cosineSimilarity(queryEmbedding, entry.embedding);
+		scored.push({ id: entry.atomId, score });
+	}
+
+	scored.sort((a, b) => b.score - a.score);
+	return scored.slice(0, topK);
+}

--- a/engine/src/run-eval.ts
+++ b/engine/src/run-eval.ts
@@ -1,0 +1,166 @@
+/**
+ * Evaluation CLI — run quality checks on atom batches.
+ *
+ * Usage:
+ *   bun run src/run-eval.ts <atoms.json>
+ *   bun run src/run-eval.ts <output.json> --raw
+ *   bun run src/run-eval.ts --compare <raw.json> <final.json>
+ *
+ * Options:
+ *   --raw           input is a per-book output file (has .extraction.atoms)
+ *   --compare       compare two files (before/after)
+ *   --format table|json   output format (default: table)
+ *   --verbose       show individual atom failures
+ */
+import { readFileSync } from "node:fs";
+import { compareReports } from "./eval/comparison";
+import { type EvalReport, runEval } from "./eval/runner";
+import { createRegistry } from "./extract/frame-registry";
+import type { CandidateAtom } from "./extract/types";
+
+function parseArgs(argv: string[]) {
+	const args = argv.slice(2);
+	const files: string[] = [];
+	let raw = false;
+	let compare = false;
+	let format: "table" | "json" = "table";
+	let verbose = false;
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--raw") raw = true;
+		else if (arg === "--compare") compare = true;
+		else if (arg === "--format")
+			format = (args[++i] ?? "table") as typeof format;
+		else if (arg === "--verbose") verbose = true;
+		else if (arg && !arg.startsWith("--")) files.push(arg);
+	}
+
+	return { files, raw, compare, format, verbose };
+}
+
+function loadAtoms(path: string, raw: boolean): CandidateAtom[] {
+	const data = JSON.parse(readFileSync(path, "utf8"));
+	if (raw && data.extraction?.atoms) {
+		return data.extraction.atoms;
+	}
+	if (Array.isArray(data)) {
+		return data;
+	}
+	throw new Error(
+		`Cannot parse atoms from ${path}. Use --raw for per-book output files.`,
+	);
+}
+
+function printTable(report: EvalReport) {
+	console.error(`Evaluation Report: ${report.source}`);
+	console.error(`Atoms evaluated: ${report.atomCount}\n`);
+
+	const header = `${"Layer".padEnd(14)}${"Check".padEnd(32)}${"Pass".padStart(6)}${"Fail".padStart(6)}${"Rate".padStart(8)}`;
+	console.error(header);
+	console.error("─".repeat(header.length));
+
+	for (const c of report.checks) {
+		const rate = `${(c.rate * 100).toFixed(1)}%`;
+		console.error(
+			`${c.layer.padEnd(14)}${c.check.replace(`${c.layer}:`, "").padEnd(32)}${String(c.pass).padStart(6)}${String(c.fail).padStart(6)}${rate.padStart(8)}`,
+		);
+	}
+
+	console.error("─".repeat(header.length));
+	console.error(
+		`${"AGGREGATE".padEnd(14)}${"atoms with ≥1 issue".padEnd(32)}${String(report.atomCount - report.aggregate.atomsWithIssues).padStart(6)}${String(report.aggregate.atomsWithIssues).padStart(6)}${`${(report.aggregate.issueRate * 100).toFixed(1)}%`.padStart(8)}`,
+	);
+}
+
+function printComparison(before: EvalReport, after: EvalReport) {
+	const comparison = compareReports(before, after);
+	console.error("Before/After Comparison");
+	console.error(
+		`  Raw extraction:  ${before.atomCount} atoms, ${before.aggregate.atomsWithIssues} issues (${(comparison.before.issueRate * 100).toFixed(1)}%)`,
+	);
+	console.error(
+		`  Final graph:     ${after.atomCount} atoms, ${after.aggregate.atomsWithIssues} issues (${(comparison.after.issueRate * 100).toFixed(1)}%)`,
+	);
+	console.error(
+		`  Reduction:       ${(comparison.before.issueRate * 100).toFixed(1)}% → ${(comparison.after.issueRate * 100).toFixed(1)}% (${comparison.reductionPct.toFixed(1)}% reduction)`,
+	);
+
+	if (comparison.perCheck.length > 0) {
+		console.error("\n  Per-check breakdown:");
+		for (const c of comparison.perCheck) {
+			if (c.beforeRate > 0 || c.afterRate > 0) {
+				console.error(
+					`    ${c.check.padEnd(38)} ${(c.beforeRate * 100).toFixed(1)}% → ${(c.afterRate * 100).toFixed(1)}%`,
+				);
+			}
+		}
+	}
+}
+
+function main() {
+	const config = parseArgs(process.argv);
+
+	if (config.files.length === 0) {
+		console.error("Usage:");
+		console.error("  bun run src/run-eval.ts <atoms.json>");
+		console.error("  bun run src/run-eval.ts <output.json> --raw");
+		console.error(
+			"  bun run src/run-eval.ts --compare <raw.json> <final.json>",
+		);
+		console.error("");
+		console.error("Options:");
+		console.error("  --raw           input is per-book output file");
+		console.error("  --compare       compare two files (before/after)");
+		console.error("  --format table|json");
+		console.error("  --verbose       show atom-level failures");
+		process.exit(1);
+	}
+
+	const registry = createRegistry();
+
+	if (config.compare && config.files.length >= 2) {
+		const beforePath = config.files[0] ?? "";
+		const afterPath = config.files[1] ?? "";
+		const beforeAtoms = loadAtoms(beforePath, true);
+		const afterAtoms = loadAtoms(afterPath, false);
+		const beforeReport = runEval(beforeAtoms, {
+			registry,
+			source: beforePath,
+		});
+		const afterReport = runEval(afterAtoms, {
+			registry,
+			source: afterPath,
+		});
+
+		if (config.format === "json") {
+			console.log(
+				JSON.stringify(compareReports(beforeReport, afterReport), null, 2),
+			);
+		} else {
+			printComparison(beforeReport, afterReport);
+		}
+		return;
+	}
+
+	// Single file evaluation
+	const filePath = config.files[0] ?? "";
+	const atoms = loadAtoms(filePath, config.raw);
+	const report = runEval(atoms, { registry, source: filePath });
+
+	if (config.format === "json") {
+		console.log(JSON.stringify(report, null, 2));
+	} else {
+		printTable(report);
+		if (config.verbose) {
+			console.error("\nFailed atoms:");
+			for (const c of report.checks) {
+				if (c.samples.length > 0) {
+					console.error(`  ${c.check}: ${c.samples.join(", ")}`);
+				}
+			}
+		}
+	}
+}
+
+main();

--- a/engine/src/run-pipeline.ts
+++ b/engine/src/run-pipeline.ts
@@ -26,6 +26,7 @@
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { createCheckpointManager, formatCheckpointStatus } from "./checkpoint";
 import { comprehend } from "./comprehend/index";
 import { normalizeChapters } from "./comprehend/structure-inference";
 import { createRegistry, extract } from "./extract/index";
@@ -51,6 +52,8 @@ function parseArgs(argv: string[]) {
 	let skipExtract = false;
 	let skipIntegrate = false;
 	let rebuildGraph = false;
+	let resume = false;
+	let checkpointStatus = false;
 
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i];
@@ -76,6 +79,10 @@ function parseArgs(argv: string[]) {
 			skipIntegrate = true;
 		} else if (arg === "--rebuild-graph") {
 			rebuildGraph = true;
+		} else if (arg === "--resume") {
+			resume = true;
+		} else if (arg === "--checkpoint-status") {
+			checkpointStatus = true;
 		} else if (!arg?.startsWith("--")) {
 			epubPath = arg ?? "";
 		}
@@ -94,6 +101,8 @@ function parseArgs(argv: string[]) {
 		skipExtract,
 		skipIntegrate,
 		rebuildGraph,
+		resume,
+		checkpointStatus,
 	};
 }
 
@@ -120,6 +129,12 @@ async function main() {
 		console.error(
 			"  --rebuild-graph                       wipe and rebuild graph",
 		);
+		console.error(
+			"  --resume                              resume from last checkpoint",
+		);
+		console.error(
+			"  --checkpoint-status                   show checkpoint status",
+		);
 		console.error("");
 		console.error(
 			"Environment: ANTHROPIC_API_KEY, KIMI_API_KEY, OPENAI_API_KEY",
@@ -127,38 +142,121 @@ async function main() {
 		process.exit(1);
 	}
 
-	// === Phase 1: Parse ===
-	console.error(`[parse] Parsing ${config.epubPath}...`);
-	const tree = await parse({
-		filePath: config.epubPath,
-		options: { extractImages: false },
+	// --- Checkpoint setup ---
+	const bookSlug = config.epubPath
+		.replace(/^.*[\\/]/, "")
+		.replace(/\.epub$/i, "")
+		.toLowerCase()
+		.replace(/[^a-z0-9-]/g, "-");
+	const checkpointDir = join(config.graphDir, ".checkpoints");
+	const checkpoint = createCheckpointManager(bookSlug, checkpointDir);
+
+	if (config.rebuildGraph) {
+		checkpoint.clear();
+	}
+
+	// --- Checkpoint status ---
+	if (config.checkpointStatus) {
+		const meta = checkpoint.getMeta();
+		if (meta) {
+			console.error(formatCheckpointStatus(meta));
+		} else {
+			console.error(`No checkpoint found for "${bookSlug}"`);
+		}
+		return;
+	}
+
+	checkpoint.setConfig({
+		comprehendProvider: config.comprehendProvider,
+		comprehendModel: config.comprehendModel,
+		extractProvider: config.extractProvider,
+		extractModel: config.extractModel,
 	});
-	console.error(
-		`[parse] Done. ${tree.chapters.length} chapters, "${tree.metadata.title}"`,
-	);
+
+	const resumePoint = config.resume ? checkpoint.getResumePoint() : null;
+	if (config.resume && resumePoint) {
+		console.error(`[checkpoint] Resuming "${bookSlug}" from ${resumePoint}`);
+	}
+
+	// === Phase 1: Parse ===
+	let tree: Awaited<ReturnType<typeof parse>>;
+
+	if (config.resume && resumePoint !== "parse" && checkpoint.load("parse")) {
+		tree = checkpoint.load("parse") as typeof tree;
+		console.error(
+			`[parse] Loaded from checkpoint (${tree.chapters.length} chapters)`,
+		);
+	} else {
+		const parseStart = Date.now();
+		console.error(`[parse] Parsing ${config.epubPath}...`);
+		tree = await parse({
+			filePath: config.epubPath,
+			options: { extractImages: false },
+		});
+		console.error(
+			`[parse] Done. ${tree.chapters.length} chapters, "${tree.metadata.title}"`,
+		);
+		checkpoint.save("parse", tree);
+		checkpoint.updateStage("parse", {
+			status: "completed",
+			completedAt: new Date().toISOString(),
+			durationMs: Date.now() - parseStart,
+		});
+	}
 
 	// === Phase 2: Comprehend ===
-	const comprehendProviderConfig: ProviderConfig = {
-		provider: config.comprehendProvider as ProviderConfig["provider"],
-		model: config.comprehendModel,
-	};
-	const comprehendLLM = withRetry(createProvider(comprehendProviderConfig));
+	const shouldSkipComprehend =
+		config.resume &&
+		resumePoint !== "parse" &&
+		resumePoint !== "comprehend" &&
+		checkpoint.load("comprehend");
 
-	console.error(
-		`[comprehend] Starting with ${config.comprehendProvider}/${config.comprehendModel}...`,
-	);
-	console.error(
-		`[comprehend] ${tree.chapters.length} chapters to process (sequential)`,
-	);
+	let comprehendResult: Awaited<ReturnType<typeof comprehend>>;
 
-	const comprehendResult = await comprehend({
-		documentTree: tree,
-		provider: comprehendLLM,
-	});
+	if (shouldSkipComprehend) {
+		comprehendResult = checkpoint.load("comprehend") as typeof comprehendResult;
+		console.error(
+			`[comprehend] Loaded from checkpoint (${comprehendResult.chapterMaps.length} maps)`,
+		);
+	} else {
+		const comprehendStart = Date.now();
+		const comprehendProviderConfig: ProviderConfig = {
+			provider: config.comprehendProvider as ProviderConfig["provider"],
+			model: config.comprehendModel,
+		};
+		const comprehendLLM = withRetry(createProvider(comprehendProviderConfig));
 
-	console.error(
-		`[comprehend] Done. ${comprehendResult.chapterMaps.length} maps, ${comprehendResult.usage.failedChapters.length} failed`,
-	);
+		console.error(
+			`[comprehend] Starting with ${config.comprehendProvider}/${config.comprehendModel}...`,
+		);
+		console.error(
+			`[comprehend] ${tree.chapters.length} chapters to process (sequential)`,
+		);
+
+		try {
+			comprehendResult = await comprehend({
+				documentTree: tree,
+				provider: comprehendLLM,
+			});
+		} catch (err) {
+			checkpoint.updateStage("comprehend", {
+				status: "failed",
+				error: String(err),
+				failedAt: new Date().toISOString(),
+			});
+			throw err;
+		}
+
+		console.error(
+			`[comprehend] Done. ${comprehendResult.chapterMaps.length} maps, ${comprehendResult.usage.failedChapters.length} failed`,
+		);
+		checkpoint.save("comprehend", comprehendResult);
+		checkpoint.updateStage("comprehend", {
+			status: "completed",
+			completedAt: new Date().toISOString(),
+			durationMs: Date.now() - comprehendStart,
+		});
+	}
 
 	if (config.skipExtract) {
 		console.error("[extract] Skipped (--skip-extract)");
@@ -167,69 +265,117 @@ async function main() {
 	}
 
 	// === Phase 3: Extract ===
-	const extractProviderConfig: ProviderConfig = {
-		provider: config.extractProvider as ProviderConfig["provider"],
-		model: config.extractModel,
-	};
-	const extractLLM = withRetry(createProvider(extractProviderConfig));
-	const registry = createRegistry();
-	const normalizedChapters = normalizeChapters(tree);
+	const shouldSkipExtract =
+		config.resume &&
+		resumePoint !== "parse" &&
+		resumePoint !== "comprehend" &&
+		resumePoint !== "extract" &&
+		checkpoint.load("extract");
 
-	console.error(
-		`[extract] Starting with ${config.extractProvider}/${config.extractModel}...`,
-	);
+	let allAtoms: CandidateAtom[];
+	let allProposedTypes: unknown[];
 
-	let totalAtoms = 0;
-	let totalExtractCalls = 0;
-	let totalExtractInput = 0;
-	let totalExtractOutput = 0;
-	const allAtoms: CandidateAtom[] = [];
-	const allProposedTypes: unknown[] = [];
-
-	for (const chapter of normalizedChapters) {
-		const map = comprehendResult.chapterMaps.find(
-			(m) => m.chapterId === chapter.id,
+	if (shouldSkipExtract) {
+		const cached = checkpoint.load<{
+			atoms: CandidateAtom[];
+			proposedTypes: unknown[];
+		}>("extract");
+		allAtoms = cached?.atoms ?? [];
+		allProposedTypes = cached?.proposedTypes ?? [];
+		console.error(
+			`[extract] Loaded from checkpoint (${allAtoms.length} atoms)`,
 		);
-		if (!map) continue;
-
-		console.error(`[extract] Chapter: ${chapter.title.slice(0, 50)}...`);
-
-		const extractResult = await extract({
-			chapter,
-			comprehensionMap: map,
-			bookMetadata: tree.metadata,
-			registry,
-			provider: extractLLM,
-		});
-
-		totalAtoms += extractResult.atoms.length;
-		totalExtractCalls += extractResult.usage.callCount;
-		totalExtractInput += extractResult.usage.inputTokens;
-		totalExtractOutput += extractResult.usage.outputTokens;
-		allAtoms.push(...extractResult.atoms);
-		allProposedTypes.push(...extractResult.proposedFrameTypes);
+	} else {
+		const extractStart = Date.now();
+		const extractProviderConfig: ProviderConfig = {
+			provider: config.extractProvider as ProviderConfig["provider"],
+			model: config.extractModel,
+		};
+		const extractLLM = withRetry(createProvider(extractProviderConfig));
+		const registry = createRegistry();
+		const normalizedChapters = normalizeChapters(tree);
 
 		console.error(
-			`  → ${extractResult.atoms.length} atoms, ${extractResult.skippedSections.length} skipped, ${extractResult.flaggedAtoms.length} flagged`,
+			`[extract] Starting with ${config.extractProvider}/${config.extractModel}...`,
+		);
+
+		let totalAtomCount = 0;
+		let totalExtractCalls = 0;
+		let totalExtractInput = 0;
+		let totalExtractOutput = 0;
+		allAtoms = [];
+		allProposedTypes = [];
+
+		try {
+			for (const chapter of normalizedChapters) {
+				const map = comprehendResult.chapterMaps.find(
+					(m) => m.chapterId === chapter.id,
+				);
+				if (!map) continue;
+
+				console.error(`[extract] Chapter: ${chapter.title.slice(0, 50)}...`);
+
+				const extractResult = await extract({
+					chapter,
+					comprehensionMap: map,
+					bookMetadata: tree.metadata,
+					registry,
+					provider: extractLLM,
+				});
+
+				totalAtomCount += extractResult.atoms.length;
+				totalExtractCalls += extractResult.usage.callCount;
+				totalExtractInput += extractResult.usage.inputTokens;
+				totalExtractOutput += extractResult.usage.outputTokens;
+				allAtoms.push(...extractResult.atoms);
+				allProposedTypes.push(...extractResult.proposedFrameTypes);
+
+				console.error(
+					`  → ${extractResult.atoms.length} atoms, ${extractResult.skippedSections.length} skipped, ${extractResult.flaggedAtoms.length} flagged`,
+				);
+			}
+		} catch (err) {
+			// Save partial progress before failing
+			checkpoint.save("extract", {
+				atoms: allAtoms,
+				proposedTypes: allProposedTypes,
+			});
+			checkpoint.updateStage("extract", {
+				status: "failed",
+				error: String(err),
+				failedAt: new Date().toISOString(),
+			});
+			throw err;
+		}
+
+		checkpoint.save("extract", {
+			atoms: allAtoms,
+			proposedTypes: allProposedTypes,
+		});
+		checkpoint.updateStage("extract", {
+			status: "completed",
+			completedAt: new Date().toISOString(),
+			durationMs: Date.now() - extractStart,
+		});
+
+		// === Report ===
+		console.error("");
+		console.error("=== Results ===");
+		console.error(
+			`Comprehend: ${comprehendResult.chapterMaps.length} chapters, ${comprehendResult.usage.callCount} calls, ${comprehendResult.usage.totalInputTokens} in / ${comprehendResult.usage.totalOutputTokens} out`,
+		);
+		console.error(
+			`Extract: ${totalAtomCount} atoms, ${totalExtractCalls} calls, ${totalExtractInput} in / ${totalExtractOutput} out`,
+		);
+		console.error(`Domain types proposed: ${allProposedTypes.length}`);
+		console.error(
+			`Registry: ${registry.getAll().length} types (${registry.getCoreTypes().length} core + ${registry.getAll().length - registry.getCoreTypes().length} domain)`,
 		);
 	}
 
-	// === Report ===
-	console.error("");
-	console.error("=== Results ===");
-	console.error(
-		`Comprehend: ${comprehendResult.chapterMaps.length} chapters, ${comprehendResult.usage.callCount} calls, ${comprehendResult.usage.totalInputTokens} in / ${comprehendResult.usage.totalOutputTokens} out`,
-	);
-	console.error(
-		`Extract: ${totalAtoms} atoms, ${totalExtractCalls} calls, ${totalExtractInput} in / ${totalExtractOutput} out`,
-	);
-	console.error(`Domain types proposed: ${allProposedTypes.length}`);
-	console.error(
-		`Registry: ${registry.getAll().length} types (${registry.getCoreTypes().length} core + ${registry.getAll().length - registry.getCoreTypes().length} domain)`,
-	);
-
 	// === Phase 4: Integrate ===
 	if (!config.skipIntegrate) {
+		const integrateStart = Date.now();
 		const embeddingProvider = createOpenAIEmbeddingProvider({
 			provider: "openai",
 			model: config.embeddingModel,
@@ -275,32 +421,46 @@ async function main() {
 			}
 		}
 
-		const knowledgeGraph = await integrate({
-			atoms: allAtoms,
-			metadata: tree.metadata,
-			existingGraph,
-			llmProvider: integrateLLM,
-			embeddingProvider,
-		});
+		try {
+			const knowledgeGraph = await integrate({
+				atoms: allAtoms,
+				metadata: tree.metadata,
+				existingGraph,
+				llmProvider: integrateLLM,
+				embeddingProvider,
+			});
 
-		if (!existsSync(graphDir)) mkdirSync(graphDir, { recursive: true });
-		writeFileSync(
-			join(graphDir, "atoms.json"),
-			JSON.stringify(knowledgeGraph.atoms, null, 2),
-		);
-		writeFileSync(
-			join(graphDir, "entities.json"),
-			JSON.stringify(knowledgeGraph.entities, null, 2),
-		);
-		writeFileSync(
-			join(graphDir, "graph.json"),
-			JSON.stringify(knowledgeGraph.graph, null, 2),
-		);
-		writeFileSync(
-			join(graphDir, "embeddings.json"),
-			JSON.stringify(knowledgeGraph.embeddings),
-		);
-		console.error(`[integrate] Graph saved to ${graphDir}`);
+			if (!existsSync(graphDir)) mkdirSync(graphDir, { recursive: true });
+			writeFileSync(
+				join(graphDir, "atoms.json"),
+				JSON.stringify(knowledgeGraph.atoms, null, 2),
+			);
+			writeFileSync(
+				join(graphDir, "entities.json"),
+				JSON.stringify(knowledgeGraph.entities, null, 2),
+			);
+			writeFileSync(
+				join(graphDir, "graph.json"),
+				JSON.stringify(knowledgeGraph.graph, null, 2),
+			);
+			writeFileSync(
+				join(graphDir, "embeddings.json"),
+				JSON.stringify(knowledgeGraph.embeddings),
+			);
+			console.error(`[integrate] Graph saved to ${graphDir}`);
+			checkpoint.updateStage("integrate", {
+				status: "completed",
+				completedAt: new Date().toISOString(),
+				durationMs: Date.now() - integrateStart,
+			});
+		} catch (err) {
+			checkpoint.updateStage("integrate", {
+				status: "failed",
+				error: String(err),
+				failedAt: new Date().toISOString(),
+			});
+			throw err;
+		}
 	} else {
 		console.error("[integrate] Skipped (--skip-integrate)");
 	}
@@ -311,11 +471,6 @@ async function main() {
 		extraction: {
 			atoms: allAtoms,
 			proposedFrameTypes: allProposedTypes,
-			usage: {
-				inputTokens: totalExtractInput,
-				outputTokens: totalExtractOutput,
-				callCount: totalExtractCalls,
-			},
 		},
 	};
 	console.log(JSON.stringify(output, null, 2));

--- a/engine/src/run-retrieve.ts
+++ b/engine/src/run-retrieve.ts
@@ -1,0 +1,173 @@
+/**
+ * Retrieval CLI — query the knowledge graph from the terminal.
+ *
+ * Usage:
+ *   bun run src/run-retrieve.ts "query" [options]
+ *
+ * Options:
+ *   --top-k <n>                 number of results (default: 10)
+ *   --method hybrid|bm25|vector retrieval method (default: hybrid)
+ *   --graph-dir <path>          data directory (default: engine/graph)
+ *   --verbose                   show per-method ranks and scores
+ *   --json                      output raw JSON to stdout
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { atomToText } from "./integrate/embedding-service";
+import { retrieve, type RetrievalResult } from "./retrieve/index";
+
+function parseArgs(argv: string[]) {
+	const args = argv.slice(2);
+	let query = "";
+	let topK = 10;
+	let method: "hybrid" | "bm25" | "vector" = "hybrid";
+	let graphDir = join(new URL(".", import.meta.url).pathname, "../graph");
+	let verbose = false;
+	let json = false;
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--top-k") {
+			topK = Number.parseInt(args[++i] ?? "10", 10);
+		} else if (arg === "--method") {
+			method = (args[++i] ?? "hybrid") as typeof method;
+		} else if (arg === "--graph-dir") {
+			graphDir = args[++i] ?? graphDir;
+		} else if (arg === "--verbose") {
+			verbose = true;
+		} else if (arg === "--json") {
+			json = true;
+		} else if (!arg?.startsWith("--")) {
+			query = arg ?? "";
+		}
+	}
+
+	return { query, topK, method, graphDir, verbose, json };
+}
+
+function truncate(text: string, maxLen: number): string {
+	return text.length > maxLen ? `${text.slice(0, maxLen - 1)}…` : text;
+}
+
+function formatResult(
+	r: RetrievalResult,
+	rank: number,
+	verbose: boolean,
+): string {
+	const text = truncate(atomToText(r.atom), 80);
+	const source = r.atom.source;
+	const sourceStr = `${source.title}, ${source.chapterId} §${source.sectionId}`;
+
+	let line = ` #${String(rank).padStart(2)}  [${r.score.toFixed(4)}] ${r.atom.frame} — ${text}\n`;
+	line += `      Source: ${truncate(sourceStr, 70)}\n`;
+
+	if (verbose) {
+		const bm25Rank = r.ranks.bm25 !== null ? `#${r.ranks.bm25}` : "—";
+		const vecRank = r.ranks.vector !== null ? `#${r.ranks.vector}` : "—";
+		line += `      BM25: ${bm25Rank}  Vector: ${vecRank}\n`;
+	}
+
+	return line;
+}
+
+async function main() {
+	const config = parseArgs(process.argv);
+
+	if (!config.query) {
+		console.error('Usage: bun run src/run-retrieve.ts "query" [options]');
+		console.error("");
+		console.error("Options:");
+		console.error("  --top-k <n>                 results to return (default: 10)");
+		console.error("  --method hybrid|bm25|vector retrieval method (default: hybrid)");
+		console.error("  --graph-dir <path>          data directory (default: engine/graph)");
+		console.error("  --verbose                   show per-method ranks");
+		console.error("  --json                      output raw JSON");
+		process.exit(1);
+	}
+
+	// Load data
+	const atomsPath = join(config.graphDir, "atoms.json");
+	const embeddingsPath = join(config.graphDir, "embeddings.json");
+
+	let atoms: import("./extract/types").CandidateAtom[];
+	try {
+		atoms = JSON.parse(readFileSync(atomsPath, "utf8"));
+	} catch {
+		console.error(`Error: Could not read ${atomsPath}`);
+		process.exit(1);
+	}
+
+	let embeddings: import("./integrate/types").VectorIndex | undefined;
+	try {
+		const raw = JSON.parse(readFileSync(embeddingsPath, "utf8"));
+		if (Array.isArray(raw) && raw.length > 0) {
+			embeddings = raw;
+		}
+	} catch {
+		if (config.method === "vector") {
+			console.error(`Error: Vector search requires ${embeddingsPath}`);
+			process.exit(1);
+		}
+		// hybrid/bm25 can proceed without embeddings
+	}
+
+	// For vector search, we need a query embedding.
+	// Without an API key, fall back to BM25-only with a message.
+	let queryEmbedding: number[] | undefined;
+	const needsVector = config.method === "vector" || config.method === "hybrid";
+
+	if (needsVector && embeddings && embeddings.length > 0) {
+		const apiKey = process.env.OPENAI_API_KEY;
+		if (apiKey) {
+			try {
+				const { createOpenAIEmbeddingProvider } = await import("./llm/openai-embedding");
+				const provider = createOpenAIEmbeddingProvider({
+					provider: "openai",
+					model: "text-embedding-3-large",
+				});
+				const [embedding] = await provider.embed([config.query]);
+				queryEmbedding = embedding;
+			} catch (err) {
+				console.error(`[warn] Embedding API call failed: ${err}`);
+			}
+		}
+
+		if (!queryEmbedding && config.method === "hybrid") {
+			console.error("[info] No OPENAI_API_KEY or embedding failed — falling back to BM25-only");
+		}
+	}
+
+	const results = await retrieve({
+		query: config.query,
+		atoms,
+		embeddings,
+		queryEmbedding,
+		topK: config.topK,
+		method: config.method,
+	});
+
+	if (config.json) {
+		console.log(JSON.stringify(results, null, 2));
+		return;
+	}
+
+	// Display
+	const methodLabel = queryEmbedding
+		? config.method
+		: config.method === "hybrid"
+			? "bm25 (vector unavailable)"
+			: config.method;
+
+	console.error(`Query: "${config.query}"`);
+	console.error(`Method: ${methodLabel}`);
+	console.error(`Results: ${results.length} of ${atoms.length} atoms\n`);
+
+	for (let i = 0; i < results.length; i++) {
+		console.error(formatResult(results[i]!, i + 1, config.verbose));
+	}
+}
+
+main().catch((err) => {
+	console.error("Retrieval failed:", err);
+	process.exit(1);
+});

--- a/engine/test/checkpoint/checkpoint.test.ts
+++ b/engine/test/checkpoint/checkpoint.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+	type CheckpointMeta,
+	createCheckpointManager,
+} from "../../src/checkpoint";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-checkpoints");
+
+afterEach(() => {
+	if (existsSync(TEST_DIR)) {
+		rmSync(TEST_DIR, { recursive: true });
+	}
+});
+
+describe("CheckpointManager", () => {
+	test("saves stage data to disk as JSON", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		const data = { chapters: [{ id: "ch1", title: "Introduction" }] };
+		mgr.save("parse", data);
+
+		const filePath = join(TEST_DIR, "test-book", "parse.json");
+		expect(existsSync(filePath)).toBe(true);
+	});
+
+	test("loads stage data back with correct shape", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		const data = { chapters: [{ id: "ch1", title: "Introduction" }] };
+		mgr.save("parse", data);
+
+		const loaded = mgr.load<typeof data>("parse");
+		expect(loaded).toEqual(data);
+	});
+
+	test("returns null for stage that has not been saved", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		expect(mgr.load("parse")).toBeNull();
+	});
+
+	test("saves and loads metadata", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "2026-03-28T10:00:00Z",
+			durationMs: 1200,
+		});
+
+		const meta = mgr.getMeta();
+		expect(meta).not.toBeNull();
+		expect(meta?.stages.parse.status).toBe("completed");
+	});
+
+	test("clear() removes all checkpoint files for a book", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.save("parse", { data: true });
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 100,
+		});
+
+		mgr.clear();
+		expect(mgr.load("parse")).toBeNull();
+		expect(mgr.getMeta()).toBeNull();
+	});
+
+	test("handles missing checkpoint directory gracefully", () => {
+		// Directory doesn't exist yet — should create it on save
+		const mgr = createCheckpointManager("new-book", TEST_DIR);
+		mgr.save("parse", { test: true });
+		expect(mgr.load("parse")).toEqual({ test: true });
+	});
+
+	test("different books have isolated checkpoints", () => {
+		const mgr1 = createCheckpointManager("book-a", TEST_DIR);
+		const mgr2 = createCheckpointManager("book-b", TEST_DIR);
+
+		mgr1.save("parse", { book: "a" });
+		mgr2.save("parse", { book: "b" });
+
+		expect(mgr1.load("parse")).toEqual({ book: "a" });
+		expect(mgr2.load("parse")).toEqual({ book: "b" });
+	});
+
+	test("getResumePoint() returns first non-completed stage", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 100,
+		});
+		mgr.updateStage("comprehend", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 5000,
+		});
+
+		expect(mgr.getResumePoint()).toBe("extract");
+	});
+
+	test("getResumePoint() returns null when all stages completed", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		for (const stage of ["parse", "comprehend", "extract", "integrate"]) {
+			mgr.updateStage(stage, {
+				status: "completed",
+				completedAt: "now",
+				durationMs: 100,
+			});
+		}
+
+		expect(mgr.getResumePoint()).toBeNull();
+	});
+
+	test("getResumePoint() returns the failed stage", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 100,
+		});
+		mgr.updateStage("comprehend", {
+			status: "failed",
+			error: "Rate limit exceeded",
+			failedAt: "now",
+		});
+
+		expect(mgr.getResumePoint()).toBe("comprehend");
+	});
+
+	test("records config in metadata", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.setConfig({
+			comprehendProvider: "kimi",
+			comprehendModel: "kimi-k2-0711-preview",
+		});
+
+		const meta = mgr.getMeta();
+		expect(meta?.config.comprehendProvider).toBe("kimi");
+	});
+});

--- a/engine/test/checkpoint/pipeline-integration.test.ts
+++ b/engine/test/checkpoint/pipeline-integration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for checkpoint integration with the pipeline.
+ *
+ * These test the CheckpointManager behavior in pipeline-like scenarios,
+ * not the full pipeline itself (which requires LLM calls).
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+	type CheckpointMeta,
+	createCheckpointManager,
+	formatCheckpointStatus,
+} from "../../src/checkpoint";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-pipeline-checkpoints");
+
+afterEach(() => {
+	if (existsSync(TEST_DIR)) {
+		rmSync(TEST_DIR, { recursive: true });
+	}
+});
+
+describe("checkpoint pipeline integration", () => {
+	test("saves checkpoint after parse stage completes", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		const parseResult = {
+			metadata: { title: "Test Book" },
+			chapters: [{ id: "ch1", title: "Chapter 1" }],
+		};
+
+		mgr.save("parse", parseResult);
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: new Date().toISOString(),
+			durationMs: 1200,
+		});
+
+		expect(mgr.load("parse")).toEqual(parseResult);
+		expect(mgr.getMeta()?.stages.parse.status).toBe("completed");
+	});
+
+	test("saves checkpoint after comprehend stage completes", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		const comprehendResult = {
+			chapterMaps: [{ chapterId: "ch1", summary: "about testing" }],
+		};
+
+		mgr.save("comprehend", comprehendResult);
+		mgr.updateStage("comprehend", {
+			status: "completed",
+			completedAt: new Date().toISOString(),
+			durationMs: 180000,
+		});
+
+		expect(mgr.load("comprehend")).toEqual(comprehendResult);
+	});
+
+	test("on resume, skips parse when parse checkpoint exists", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.save("parse", { data: "parse-output" });
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 100,
+		});
+
+		// Simulate resume: check what to skip
+		const resumePoint = mgr.getResumePoint();
+		expect(resumePoint).toBe("comprehend"); // parse done, start from comprehend
+
+		// Load parse output instead of re-running
+		const cached = mgr.load("parse");
+		expect(cached).toEqual({ data: "parse-output" });
+	});
+
+	test("on resume, skips parse+comprehend when both checkpoints exist", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.save("parse", { data: "parse" });
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 100,
+		});
+		mgr.save("comprehend", { data: "comprehend" });
+		mgr.updateStage("comprehend", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 5000,
+		});
+
+		expect(mgr.getResumePoint()).toBe("extract");
+	});
+
+	test("on resume with no checkpoints, runs from beginning", () => {
+		const mgr = createCheckpointManager("fresh-book", TEST_DIR);
+		// No checkpoints saved
+		expect(mgr.getResumePoint()).toBeNull(); // no meta = no resume point
+		expect(mgr.getMeta()).toBeNull();
+	});
+
+	test("rebuild clears checkpoints", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.save("parse", { data: true });
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 100,
+		});
+
+		// Simulate --rebuild-graph
+		mgr.clear();
+		expect(mgr.load("parse")).toBeNull();
+		expect(mgr.getMeta()).toBeNull();
+	});
+
+	test("checkpoint-status formats stage summary", () => {
+		const meta: CheckpointMeta = {
+			bookSlug: "designing-data-intensive-applications",
+			startedAt: "2026-03-28T10:00:00Z",
+			stages: {
+				parse: {
+					status: "completed",
+					completedAt: "2026-03-28T10:00:01Z",
+					durationMs: 1200,
+				},
+				comprehend: {
+					status: "completed",
+					completedAt: "2026-03-28T10:03:12Z",
+					durationMs: 192000,
+				},
+				extract: {
+					status: "failed",
+					error: "Rate limit exceeded",
+					failedAt: "2026-03-28T10:05:00Z",
+				},
+				integrate: { status: "pending" },
+			},
+			config: {
+				comprehendProvider: "kimi",
+				comprehendModel: "kimi-k2-0711-preview",
+			},
+		};
+
+		const output = formatCheckpointStatus(meta);
+		expect(output).toContain("designing-data-intensive-applications");
+		expect(output).toContain("✓ completed");
+		expect(output).toContain("✗ failed");
+		expect(output).toContain("Rate limit exceeded");
+		expect(output).toContain("· pending");
+	});
+
+	test("checkpoint config mismatch is detectable", () => {
+		const mgr = createCheckpointManager("test-book", TEST_DIR);
+		mgr.setConfig({
+			comprehendProvider: "kimi",
+			comprehendModel: "kimi-k2-0711-preview",
+		});
+		mgr.updateStage("parse", {
+			status: "completed",
+			completedAt: "now",
+			durationMs: 100,
+		});
+
+		const meta = mgr.getMeta();
+		// Pipeline can compare current config vs checkpoint config
+		const currentConfig = {
+			comprehendProvider: "anthropic",
+			comprehendModel: "claude-sonnet",
+		};
+
+		const mismatch =
+			meta?.config.comprehendProvider !== currentConfig.comprehendProvider ||
+			meta?.config.comprehendModel !== currentConfig.comprehendModel;
+		expect(mismatch).toBe(true);
+	});
+});

--- a/engine/test/eval/checks.test.ts
+++ b/engine/test/eval/checks.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { CHECKS, type CheckContext } from "../../src/eval/checks";
+import { createRegistry } from "../../src/extract/frame-registry";
+import {
+	allRolesFilled,
+	compoundRole,
+	confidenceOutlier,
+	emptyConditions,
+	emptyRoles,
+	missingFrame,
+	missingOptionalRole,
+	missingRequiredRole,
+	passingAtom,
+	specificContent,
+	unregisteredFrame,
+	vagueContent,
+	vagueContentPattern,
+} from "./fixtures/sample-atoms";
+
+const registry = createRegistry();
+
+/** Frame stats: definition atoms average 0.9 confidence, σ = 0.05 */
+const frameStats = new Map([
+	["definition", { meanConfidence: 0.9, stdConfidence: 0.05 }],
+	["example_of", { meanConfidence: 0.85, stdConfidence: 0.06 }],
+]);
+
+const ctx: CheckContext = { registry, frameStats };
+
+function runCheck(
+	checkId: string,
+	atom: Parameters<(typeof CHECKS)[number]["run"]>[0],
+) {
+	const check = CHECKS.find((c) => c.id === checkId);
+	if (!check) throw new Error(`Unknown check: ${checkId}`);
+	return check.run(atom, ctx);
+}
+
+describe("structural checks", () => {
+	test("structural:missing-frame — fails on empty frame", () => {
+		expect(runCheck("structural:missing-frame", missingFrame).pass).toBe(false);
+	});
+
+	test("structural:missing-frame — passes on valid frame", () => {
+		expect(runCheck("structural:missing-frame", passingAtom).pass).toBe(true);
+	});
+
+	test("structural:empty-roles — fails on {} roles", () => {
+		expect(runCheck("structural:empty-roles", emptyRoles).pass).toBe(false);
+	});
+
+	test("structural:empty-roles — passes with at least one role", () => {
+		expect(runCheck("structural:empty-roles", passingAtom).pass).toBe(true);
+	});
+
+	test("structural:unregistered-frame — fails on unknown frame", () => {
+		expect(
+			runCheck("structural:unregistered-frame", unregisteredFrame).pass,
+		).toBe(false);
+	});
+
+	test("structural:unregistered-frame — passes on core frame", () => {
+		expect(runCheck("structural:unregistered-frame", passingAtom).pass).toBe(
+			true,
+		);
+	});
+});
+
+describe("schema checks", () => {
+	test("schema:missing-required-role — fails when required role absent", () => {
+		const result = runCheck(
+			"schema:missing-required-role",
+			missingRequiredRole,
+		);
+		expect(result.pass).toBe(false);
+		expect(result.detail).toContain("meaning");
+	});
+
+	test("schema:missing-required-role — passes when all required roles present", () => {
+		expect(runCheck("schema:missing-required-role", passingAtom).pass).toBe(
+			true,
+		);
+	});
+
+	test("schema:missing-optional-role — flags when optional role absent", () => {
+		const result = runCheck(
+			"schema:missing-optional-role",
+			missingOptionalRole,
+		);
+		expect(result.pass).toBe(false);
+		expect(result.detail).toContain("detail");
+	});
+
+	test("schema:missing-optional-role — passes when all roles filled", () => {
+		expect(runCheck("schema:missing-optional-role", allRolesFilled).pass).toBe(
+			true,
+		);
+	});
+});
+
+describe("semantic checks", () => {
+	test("semantic:compound-role — fails on 3+ sentence role value", () => {
+		const result = runCheck("semantic:compound-role", compoundRole);
+		expect(result.pass).toBe(false);
+	});
+
+	test("semantic:compound-role — passes on single statement", () => {
+		expect(runCheck("semantic:compound-role", specificContent).pass).toBe(true);
+	});
+
+	test("semantic:vague-content — fails on 'important'", () => {
+		expect(runCheck("semantic:vague-content", vagueContent).pass).toBe(false);
+	});
+
+	test("semantic:vague-content — fails on 'various factors' pattern", () => {
+		expect(runCheck("semantic:vague-content", vagueContentPattern).pass).toBe(
+			false,
+		);
+	});
+
+	test("semantic:vague-content — passes on specific content", () => {
+		expect(runCheck("semantic:vague-content", specificContent).pass).toBe(true);
+	});
+
+	test("semantic:confidence-outlier — fails when > 2σ from frame mean", () => {
+		// confidence 0.3, mean 0.9, σ 0.05 → 12σ away
+		const result = runCheck("semantic:confidence-outlier", confidenceOutlier);
+		expect(result.pass).toBe(false);
+	});
+
+	test("semantic:confidence-outlier — passes for normal confidence", () => {
+		expect(runCheck("semantic:confidence-outlier", passingAtom).pass).toBe(
+			true,
+		);
+	});
+
+	test("semantic:empty-conditions — fails on empty conditions array", () => {
+		expect(runCheck("semantic:empty-conditions", emptyConditions).pass).toBe(
+			false,
+		);
+	});
+
+	test("semantic:empty-conditions — passes with conditions", () => {
+		expect(runCheck("semantic:empty-conditions", passingAtom).pass).toBe(true);
+	});
+});
+
+describe("check registry", () => {
+	test("all checks have unique IDs", () => {
+		const ids = CHECKS.map((c) => c.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	test("all checks have layer and severity", () => {
+		for (const check of CHECKS) {
+			expect(["structural", "schema", "semantic"]).toContain(check.layer);
+			expect(["reject", "flag"]).toContain(check.severity);
+		}
+	});
+});

--- a/engine/test/eval/comparison.test.ts
+++ b/engine/test/eval/comparison.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type ComparisonReport,
+	compareReports,
+} from "../../src/eval/comparison";
+import type { EvalReport } from "../../src/eval/runner";
+
+function makeReport(overrides: Partial<EvalReport>): EvalReport {
+	return {
+		source: "test",
+		atomCount: 100,
+		checks: [
+			{
+				check: "structural:missing-frame",
+				layer: "structural",
+				severity: "reject",
+				pass: 100,
+				fail: 0,
+				rate: 0,
+				samples: [],
+			},
+			{
+				check: "semantic:empty-conditions",
+				layer: "semantic",
+				severity: "flag",
+				pass: 60,
+				fail: 40,
+				rate: 0.4,
+				samples: ["a", "b", "c"],
+			},
+		],
+		aggregate: { atomsWithIssues: 40, issueRate: 0.4 },
+		...overrides,
+	};
+}
+
+describe("compareReports", () => {
+	test("computes delta between two reports", () => {
+		const before = makeReport({
+			aggregate: { atomsWithIssues: 37, issueRate: 0.37 },
+		});
+		const after = makeReport({
+			aggregate: { atomsWithIssues: 2, issueRate: 0.02 },
+		});
+		const comparison = compareReports(before, after);
+
+		expect(comparison.before.issueRate).toBeCloseTo(0.37, 2);
+		expect(comparison.after.issueRate).toBeCloseTo(0.02, 2);
+		expect(comparison.reductionPct).toBeGreaterThan(90);
+	});
+
+	test("handles different atom counts", () => {
+		const before = makeReport({
+			atomCount: 150,
+			aggregate: { atomsWithIssues: 60, issueRate: 0.4 },
+		});
+		const after = makeReport({
+			atomCount: 100,
+			aggregate: { atomsWithIssues: 2, issueRate: 0.02 },
+		});
+		const comparison = compareReports(before, after);
+		expect(comparison.before.atomCount).toBe(150);
+		expect(comparison.after.atomCount).toBe(100);
+	});
+
+	test("produces per-check deltas for shared checks", () => {
+		const before = makeReport({
+			checks: [
+				{
+					check: "semantic:empty-conditions",
+					layer: "semantic",
+					severity: "flag",
+					pass: 60,
+					fail: 40,
+					rate: 0.4,
+					samples: [],
+				},
+				{
+					check: "structural:missing-frame",
+					layer: "structural",
+					severity: "reject",
+					pass: 95,
+					fail: 5,
+					rate: 0.05,
+					samples: [],
+				},
+			],
+		});
+		const after = makeReport({
+			checks: [
+				{
+					check: "semantic:empty-conditions",
+					layer: "semantic",
+					severity: "flag",
+					pass: 95,
+					fail: 5,
+					rate: 0.05,
+					samples: [],
+				},
+				{
+					check: "structural:missing-frame",
+					layer: "structural",
+					severity: "reject",
+					pass: 100,
+					fail: 0,
+					rate: 0,
+					samples: [],
+				},
+			],
+		});
+
+		const comparison = compareReports(before, after);
+		expect(comparison.perCheck.length).toBe(2);
+		const condCheck = comparison.perCheck.find(
+			(c) => c.check === "semantic:empty-conditions",
+		);
+		expect(condCheck).toBeDefined();
+		expect(condCheck?.beforeRate).toBeCloseTo(0.4, 2);
+		expect(condCheck?.afterRate).toBeCloseTo(0.05, 2);
+	});
+
+	test("handles zero before rate without division error", () => {
+		const before = makeReport({
+			aggregate: { atomsWithIssues: 0, issueRate: 0 },
+		});
+		const after = makeReport({
+			aggregate: { atomsWithIssues: 0, issueRate: 0 },
+		});
+		const comparison = compareReports(before, after);
+		expect(comparison.reductionPct).toBe(0);
+	});
+});

--- a/engine/test/eval/fixtures/sample-atoms.ts
+++ b/engine/test/eval/fixtures/sample-atoms.ts
@@ -1,0 +1,143 @@
+/**
+ * Test fixtures for eval checks.
+ *
+ * Each atom is designed to trigger (or pass) a specific check.
+ * Named by what they test: passing_*, failing_*.
+ */
+import type { CandidateAtom } from "../../../src/extract/types";
+
+function makeAtom(overrides: Partial<CandidateAtom>): CandidateAtom {
+	return {
+		id: "eval-test-0",
+		frame: "definition",
+		roles: {
+			term: "replication lag",
+			meaning: "the delay between leader write and follower reflection",
+		},
+		conditions: ["in distributed databases"],
+		confidence: 0.85,
+		source: {
+			title: "Test Book",
+			authors: ["Author"],
+			chapterId: "ch1",
+			sectionId: "s1",
+		},
+		domain: ["distributed systems"],
+		examples: [],
+		flags: [],
+		...overrides,
+	};
+}
+
+// --- Structural checks ---
+
+/** Should pass all structural checks */
+export const passingAtom = makeAtom({ id: "pass-01" });
+
+/** Missing frame → structural:missing-frame */
+export const missingFrame = makeAtom({ id: "fail-struct-01", frame: "" });
+
+/** Empty roles → structural:empty-roles */
+export const emptyRoles = makeAtom({ id: "fail-struct-02", roles: {} });
+
+/** Unregistered frame type → structural:unregistered-frame */
+export const unregisteredFrame = makeAtom({
+	id: "fail-struct-03",
+	frame: "nonexistent_frame_type",
+});
+
+// --- Schema checks ---
+
+/** Missing required role "meaning" for definition frame → schema:missing-required-role */
+export const missingRequiredRole = makeAtom({
+	id: "fail-schema-01",
+	frame: "definition",
+	roles: { term: "something" },
+	// "meaning" is required for definition but missing
+});
+
+/** Missing optional role "detail" for example_of → schema:missing-optional-role */
+export const missingOptionalRole = makeAtom({
+	id: "fail-schema-02",
+	frame: "example_of",
+	roles: { instance: "Toyota", concept: "lean manufacturing" },
+	// "detail" is optional but missing
+});
+
+/** All roles filled → passes schema checks */
+export const allRolesFilled = makeAtom({
+	id: "pass-schema-01",
+	frame: "example_of",
+	roles: {
+		instance: "Toyota Production System",
+		concept: "lean manufacturing",
+		detail: "eliminates waste through just-in-time production",
+	},
+});
+
+// --- Semantic checks ---
+
+/** Compound role value (3+ sentences) → semantic:compound-role */
+export const compoundRole = makeAtom({
+	id: "fail-semantic-01",
+	roles: {
+		term: "replication",
+		meaning:
+			"Replication is the process of copying data. It ensures high availability. It can be synchronous or asynchronous. There are trade-offs between consistency and latency.",
+	},
+});
+
+/** Vague/generic content → semantic:vague-content */
+export const vagueContent = makeAtom({
+	id: "fail-semantic-02",
+	roles: {
+		term: "concept",
+		meaning: "important",
+	},
+});
+
+/** Another vague pattern */
+export const vagueContentPattern = makeAtom({
+	id: "fail-semantic-03",
+	roles: {
+		term: "factors",
+		meaning: "various factors affect the outcome",
+	},
+});
+
+/** Confidence outlier — way below frame-type mean */
+export const confidenceOutlier = makeAtom({
+	id: "fail-semantic-04",
+	confidence: 0.3,
+	// Other definition atoms average ~0.9, so 0.3 is a clear outlier
+});
+
+/** Empty conditions → semantic:empty-conditions */
+export const emptyConditions = makeAtom({
+	id: "fail-semantic-05",
+	conditions: [],
+});
+
+/** Short but specific content → passes semantic checks */
+export const specificContent = makeAtom({
+	id: "pass-semantic-01",
+	roles: {
+		term: "replication lag",
+		meaning:
+			"the delay between a write on the leader and its reflection on a follower replica",
+	},
+	conditions: ["in distributed databases with asynchronous replication"],
+	confidence: 0.85,
+});
+
+// --- Mixed: atoms for aggregate testing ---
+
+export const batchAtoms: CandidateAtom[] = [
+	passingAtom,
+	specificContent,
+	allRolesFilled,
+	emptyConditions,
+	compoundRole,
+	vagueContent,
+	missingRequiredRole,
+];

--- a/engine/test/eval/integration.test.ts
+++ b/engine/test/eval/integration.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Integration tests — run eval against real processed data.
+ *
+ * Depends on engine/graph/ and engine/output/ existing with processed books.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { compareReports } from "../../src/eval/comparison";
+import { runEval } from "../../src/eval/runner";
+import { createRegistry } from "../../src/extract/frame-registry";
+import type { CandidateAtom } from "../../src/extract/types";
+
+const graphDir = join(import.meta.dir, "../../graph");
+const outputDir = join(import.meta.dir, "../../output");
+const hasGraph = existsSync(join(graphDir, "atoms.json"));
+const hasDDIA = existsSync(
+	join(outputDir, "designing-data-intensive-applications.json"),
+);
+
+const registry = createRegistry();
+
+describe.skipIf(!hasGraph)("eval integration — graph atoms", () => {
+	test("structural checks all pass on final graph atoms", () => {
+		const atoms = JSON.parse(
+			readFileSync(join(graphDir, "atoms.json"), "utf8"),
+		) as CandidateAtom[];
+		const report = runEval(atoms, {
+			registry,
+			checks: [
+				"structural:missing-frame",
+				"structural:empty-roles",
+				"structural:unregistered-frame",
+			],
+		});
+		// All structural checks should pass — atoms were already validated
+		for (const c of report.checks) {
+			expect(c.fail).toBe(0);
+		}
+	});
+});
+
+describe.skipIf(!hasDDIA)("eval integration — raw extraction", () => {
+	test("DDIA raw extraction has meaningful flag rate", () => {
+		const raw = JSON.parse(
+			readFileSync(
+				join(outputDir, "designing-data-intensive-applications.json"),
+				"utf8",
+			),
+		);
+		const atoms = raw.extraction.atoms as CandidateAtom[];
+		const report = runEval(atoms, { registry });
+
+		// Known: ~37-41% of DDIA atoms have issues
+		expect(report.aggregate.issueRate).toBeGreaterThan(0.3);
+		expect(report.aggregate.issueRate).toBeLessThan(0.6);
+	});
+
+	test("comparison between raw and graph shows detection", () => {
+		const raw = JSON.parse(
+			readFileSync(
+				join(outputDir, "designing-data-intensive-applications.json"),
+				"utf8",
+			),
+		);
+		const rawAtoms = raw.extraction.atoms as CandidateAtom[];
+		const graphAtoms = JSON.parse(
+			readFileSync(join(graphDir, "atoms.json"), "utf8"),
+		) as CandidateAtom[];
+
+		const beforeReport = runEval(rawAtoms, { registry, source: "raw" });
+		const afterReport = runEval(graphAtoms, { registry, source: "graph" });
+
+		const comparison = compareReports(beforeReport, afterReport);
+
+		// Both should show meaningful issue rates
+		expect(comparison.before.issueRate).toBeGreaterThan(0.3);
+		// After should also show issues (they're detected, not removed)
+		expect(comparison.after.issueRate).toBeGreaterThan(0);
+	});
+});

--- a/engine/test/eval/runner.test.ts
+++ b/engine/test/eval/runner.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { runEval } from "../../src/eval/runner";
+import { createRegistry } from "../../src/extract/frame-registry";
+import {
+	batchAtoms,
+	compoundRole,
+	emptyConditions,
+	missingRequiredRole,
+	passingAtom,
+	vagueContent,
+} from "./fixtures/sample-atoms";
+
+const registry = createRegistry();
+
+describe("runEval", () => {
+	test("runs all checks against a batch of atoms", () => {
+		const report = runEval(batchAtoms, { registry });
+		expect(report.atomCount).toBe(batchAtoms.length);
+		expect(report.checks.length).toBeGreaterThan(0);
+	});
+
+	test("counts pass/fail per check correctly", () => {
+		const report = runEval(batchAtoms, { registry });
+		const emptyCondCheck = report.checks.find(
+			(c) => c.check === "semantic:empty-conditions",
+		);
+		expect(emptyCondCheck).toBeDefined();
+		if (!emptyCondCheck) return;
+		// batchAtoms has some atoms with conditions, some without
+		expect(emptyCondCheck.pass + emptyCondCheck.fail).toBe(batchAtoms.length);
+	});
+
+	test("computes aggregate 'atoms with at least one issue'", () => {
+		const report = runEval(batchAtoms, { registry });
+		// At least emptyConditions, compoundRole, vagueContent, missingRequiredRole have issues
+		expect(report.aggregate.atomsWithIssues).toBeGreaterThanOrEqual(4);
+		expect(report.aggregate.issueRate).toBeGreaterThan(0);
+		expect(report.aggregate.issueRate).toBeLessThanOrEqual(1);
+	});
+
+	test("includes up to 3 sample atom IDs per failed check", () => {
+		const report = runEval(batchAtoms, { registry });
+		for (const check of report.checks) {
+			expect(check.samples.length).toBeLessThanOrEqual(3);
+			if (check.fail > 0) {
+				expect(check.samples.length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	test("handles empty atom array without crashing", () => {
+		const report = runEval([], { registry });
+		expect(report.atomCount).toBe(0);
+		expect(report.aggregate.atomsWithIssues).toBe(0);
+		expect(report.aggregate.issueRate).toBe(0);
+	});
+
+	test("atoms with multiple failing checks counted once in aggregate", () => {
+		// vagueContent has vague role AND empty conditions → multiple failures
+		// but should count as 1 atom with issues
+		const report = runEval([vagueContent], { registry });
+		expect(report.aggregate.atomsWithIssues).toBe(1);
+	});
+
+	test("filters to specific checks when provided", () => {
+		const report = runEval(batchAtoms, {
+			registry,
+			checks: ["structural:missing-frame", "structural:empty-roles"],
+		});
+		expect(report.checks.length).toBe(2);
+		expect(report.checks.map((c) => c.check)).toContain(
+			"structural:missing-frame",
+		);
+	});
+});

--- a/engine/test/retrieve/bm25.test.ts
+++ b/engine/test/retrieve/bm25.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { atomToText } from "../../src/integrate/embedding-service";
+import { buildBM25Index, queryBM25 } from "../../src/retrieve/bm25";
+import {
+	allFixtureAtoms,
+	behaviorAtoms,
+	distSysAtoms,
+	industryAtoms,
+} from "./fixtures/sample-atoms";
+
+const docs = allFixtureAtoms.map((a) => ({ id: a.id, text: atomToText(a) }));
+
+describe("buildBM25Index", () => {
+	test("builds index from document array", () => {
+		const index = buildBM25Index(docs);
+		expect(index.docCount).toBe(docs.length);
+		expect(index.avgDocLength).toBeGreaterThan(0);
+	});
+
+	test("computes IDF — rare terms have higher IDF than common terms", () => {
+		const index = buildBM25Index(docs);
+		// "replication" appears in several dist-sys docs
+		// "photosynthesis" appears in only 1 doc
+		const idfReplication = index.idf.get("replication") ?? 0;
+		const idfPhotosynthesis = index.idf.get("photosynthesis") ?? 0;
+		expect(idfPhotosynthesis).toBeGreaterThan(idfReplication);
+	});
+});
+
+describe("queryBM25", () => {
+	const index = buildBM25Index(docs);
+
+	test("ranks replication-related atoms highest for 'replication lag'", () => {
+		const results = queryBM25(index, "replication lag", 5);
+		expect(results.length).toBe(5);
+		// Top results should be dist-sys atoms that mention replication lag
+		const topIds = results.slice(0, 3).map((r) => r.id);
+		const hasDistSys = topIds.some((id) => id.startsWith("dist-"));
+		expect(hasDistSys).toBe(true);
+	});
+
+	test("ranks industry atoms highest for CJK query '行业生命周期'", () => {
+		const results = queryBM25(index, "行业生命周期", 5);
+		expect(results.length).toBeGreaterThan(0);
+		// Top result should be ind-01 (taxonomy of 行业生命周期)
+		expect(results[0]?.id).toBe("ind-01");
+	});
+
+	test("returns empty for query with no matching terms", () => {
+		const results = queryBM25(index, "xyzzy plugh", 5);
+		expect(results).toEqual([]);
+	});
+
+	test("handles query terms not in corpus without crashing", () => {
+		const results = queryBM25(index, "replication xyzzy", 5);
+		// Should still return results for "replication", ignore "xyzzy"
+		expect(results.length).toBeGreaterThan(0);
+	});
+
+	test("respects top-k limit", () => {
+		const results = queryBM25(index, "replication lag", 2);
+		expect(results.length).toBe(2);
+	});
+
+	test("documents with more matching terms rank higher", () => {
+		// "replication lag" has 2 terms; docs matching both should rank higher
+		// than docs matching only one
+		const results = queryBM25(index, "replication lag", docs.length);
+		if (results.length >= 2) {
+			expect(results[0]?.score).toBeGreaterThan(
+				results[results.length - 1]?.score,
+			);
+		}
+	});
+
+	test("scores are positive for matching documents", () => {
+		const results = queryBM25(index, "feedback loop habit", 5);
+		for (const r of results) {
+			expect(r.score).toBeGreaterThan(0);
+		}
+	});
+
+	test("returns results sorted by descending score", () => {
+		const results = queryBM25(index, "penetration rate industry", 10);
+		for (let i = 1; i < results.length; i++) {
+			expect(results[i - 1]?.score).toBeGreaterThanOrEqual(results[i]?.score);
+		}
+	});
+});

--- a/engine/test/retrieve/fixtures/sample-atoms.ts
+++ b/engine/test/retrieve/fixtures/sample-atoms.ts
@@ -1,0 +1,303 @@
+/**
+ * Test fixtures for retrieval tests.
+ *
+ * 15 atoms across 3 languages/domains with known text content
+ * so we can predict BM25 and vector search rankings.
+ *
+ * Designed retrieval scenarios:
+ * - Query "replication lag" should rank dist-sys atoms highest (BM25 exact match)
+ * - Query "行业生命周期" should rank industry-lifecycle atoms highest (CJK bigram match)
+ * - Query "habit formation feedback" should rank behavioral atoms highest
+ * - "penetration rate threshold" should match threshold + heuristic atoms
+ */
+import type { CandidateAtom } from "../../../src/extract/types";
+
+function makeAtom(overrides: Partial<CandidateAtom>): CandidateAtom {
+	return {
+		id: "test-0",
+		frame: "definition",
+		roles: { term: "test", meaning: "test" },
+		conditions: [],
+		confidence: 0.85,
+		source: {
+			title: "Test Book",
+			authors: ["Author"],
+			chapterId: "ch1",
+			sectionId: "s1",
+		},
+		domain: ["testing"],
+		examples: [],
+		flags: [],
+		...overrides,
+	};
+}
+
+// --- Distributed Systems (English) ---
+
+export const distSysAtoms: CandidateAtom[] = [
+	makeAtom({
+		id: "dist-01",
+		frame: "definition",
+		roles: {
+			term: "replication lag",
+			meaning:
+				"the delay between a write on the leader and its reflection on a follower",
+		},
+		domain: ["distributed systems"],
+		source: {
+			title: "Distributed Systems",
+			authors: ["Author A"],
+			chapterId: "ch1",
+			sectionId: "s1",
+		},
+	}),
+	makeAtom({
+		id: "dist-02",
+		frame: "causal",
+		roles: {
+			cause: "replication lag",
+			effect: "stale reads from follower replicas",
+		},
+		domain: ["distributed systems"],
+		source: {
+			title: "Distributed Systems",
+			authors: ["Author A"],
+			chapterId: "ch1",
+			sectionId: "s2",
+		},
+	}),
+	makeAtom({
+		id: "dist-03",
+		frame: "principle",
+		roles: {
+			statement: "strong consistency requires synchronous replication",
+			scope: "distributed databases",
+		},
+		domain: ["distributed systems"],
+		source: {
+			title: "Distributed Systems",
+			authors: ["Author A"],
+			chapterId: "ch2",
+			sectionId: "s1",
+		},
+	}),
+	makeAtom({
+		id: "dist-04",
+		frame: "threshold",
+		roles: {
+			metric: "replication lag",
+			threshold_value: "100ms",
+			transition: "acceptable to degraded read consistency",
+			direction: "above",
+		},
+		domain: ["distributed systems"],
+		source: {
+			title: "Distributed Systems",
+			authors: ["Author A"],
+			chapterId: "ch1",
+			sectionId: "s3",
+		},
+	}),
+	makeAtom({
+		id: "dist-05",
+		frame: "heuristic",
+		roles: {
+			situation: "when replication lag exceeds SLA threshold",
+			action: "route reads to leader or use read-your-writes consistency",
+			rationale: "prevents serving stale data to the writing user",
+		},
+		domain: ["distributed systems"],
+		source: {
+			title: "Distributed Systems",
+			authors: ["Author A"],
+			chapterId: "ch1",
+			sectionId: "s4",
+		},
+	}),
+];
+
+// --- Industry Analysis (Chinese) ---
+
+export const industryAtoms: CandidateAtom[] = [
+	makeAtom({
+		id: "ind-01",
+		frame: "taxonomy",
+		roles: {
+			concept: "行业生命周期",
+			categories: "导入期、成长期、成熟期、衰退期",
+			basis: "渗透率和市场增速",
+		},
+		domain: ["行业分析"],
+		source: {
+			title: "如何快速了解一个行业",
+			authors: ["Author B"],
+			chapterId: "ch1",
+			sectionId: "s1",
+		},
+	}),
+	makeAtom({
+		id: "ind-02",
+		frame: "threshold",
+		roles: {
+			metric: "渗透率",
+			threshold_value: "10%",
+			transition: "导入期向成长期转换",
+			direction: "above",
+		},
+		domain: ["行业分析"],
+		source: {
+			title: "如何快速了解一个行业",
+			authors: ["Author B"],
+			chapterId: "ch1",
+			sectionId: "s2",
+		},
+	}),
+	makeAtom({
+		id: "ind-03",
+		frame: "heuristic",
+		roles: {
+			situation: "判断行业所处阶段时",
+			action: "先看渗透率确定大致阶段再看增速验证",
+			rationale: "渗透率是最可靠的阶段判断指标",
+		},
+		domain: ["行业分析"],
+		source: {
+			title: "如何快速了解一个行业",
+			authors: ["Author B"],
+			chapterId: "ch1",
+			sectionId: "s3",
+		},
+	}),
+	makeAtom({
+		id: "ind-04",
+		frame: "principle",
+		roles: {
+			statement:
+				"penetration rate is the most reliable indicator of industry lifecycle stage",
+			scope: "industry analysis",
+			implication:
+				"use penetration rate before growth rate when determining stage",
+		},
+		domain: ["industry analysis"],
+		source: {
+			title: "如何快速了解一个行业",
+			authors: ["Author B"],
+			chapterId: "ch1",
+			sectionId: "s4",
+		},
+	}),
+];
+
+// --- Behavioral Science (Mixed EN/CJK) ---
+
+export const behaviorAtoms: CandidateAtom[] = [
+	makeAtom({
+		id: "beh-01",
+		frame: "definition",
+		roles: {
+			term: "feedback loop",
+			meaning:
+				"a cycle where the output of a behavior influences subsequent behavior",
+		},
+		domain: ["behavioral science"],
+		source: {
+			title: "Tiny Habits",
+			authors: ["Author C"],
+			chapterId: "ch1",
+			sectionId: "s1",
+		},
+	}),
+	makeAtom({
+		id: "beh-02",
+		frame: "causal",
+		roles: {
+			cause: "positive feedback loop in habit formation",
+			effect: "exponential behavior change over time",
+		},
+		domain: ["behavioral science"],
+		source: {
+			title: "Tiny Habits",
+			authors: ["Author C"],
+			chapterId: "ch2",
+			sectionId: "s1",
+		},
+	}),
+	makeAtom({
+		id: "beh-03",
+		frame: "heuristic",
+		roles: {
+			situation: "when building a new habit",
+			action: "celebrate immediately after performing the behavior",
+			rationale:
+				"celebration creates positive emotions that reinforce the neural pathway",
+		},
+		domain: ["behavioral science"],
+		source: {
+			title: "Tiny Habits",
+			authors: ["Author C"],
+			chapterId: "ch2",
+			sectionId: "s2",
+		},
+	}),
+	makeAtom({
+		id: "beh-04",
+		frame: "procedure",
+		roles: {
+			goal: "establish a tiny habit",
+			steps:
+				"1. anchor to existing routine 2. make behavior tiny 3. celebrate immediately",
+			context: "habit formation",
+		},
+		domain: ["behavioral science"],
+		source: {
+			title: "Tiny Habits",
+			authors: ["Author C"],
+			chapterId: "ch3",
+			sectionId: "s1",
+		},
+	}),
+];
+
+// --- Unrelated atom (noise for retrieval tests) ---
+
+export const noiseAtoms: CandidateAtom[] = [
+	makeAtom({
+		id: "noise-01",
+		frame: "definition",
+		roles: {
+			term: "photosynthesis",
+			meaning:
+				"the process by which plants convert sunlight into chemical energy",
+		},
+		domain: ["biology"],
+		source: {
+			title: "Biology 101",
+			authors: ["Author D"],
+			chapterId: "ch1",
+			sectionId: "s1",
+		},
+	}),
+	makeAtom({
+		id: "noise-02",
+		frame: "formula",
+		roles: {
+			name: "quadratic formula",
+			expression: "x = (-b ± √(b²-4ac)) / 2a",
+			terms: "a, b, c are coefficients of ax² + bx + c = 0",
+		},
+		domain: ["mathematics"],
+		source: {
+			title: "Algebra Fundamentals",
+			authors: ["Author E"],
+			chapterId: "ch1",
+			sectionId: "s1",
+		},
+	}),
+];
+
+export const allFixtureAtoms: CandidateAtom[] = [
+	...distSysAtoms,
+	...industryAtoms,
+	...behaviorAtoms,
+	...noiseAtoms,
+];

--- a/engine/test/retrieve/hybrid.test.ts
+++ b/engine/test/retrieve/hybrid.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { type RankedList, fuseResults } from "../../src/retrieve/hybrid";
+
+describe("fuseResults", () => {
+	test("fuses two ranked lists using RRF", () => {
+		const lists: RankedList[] = [
+			{
+				method: "bm25",
+				results: [
+					{ id: "a", score: 5.0 },
+					{ id: "b", score: 3.0 },
+					{ id: "c", score: 1.0 },
+				],
+			},
+			{
+				method: "vector",
+				results: [
+					{ id: "b", score: 0.95 },
+					{ id: "a", score: 0.8 },
+					{ id: "d", score: 0.7 },
+				],
+			},
+		];
+
+		const fused = fuseResults(lists, 10);
+		expect(fused.length).toBe(4); // a, b, c, d
+
+		// "b" is #2 in bm25, #1 in vector → RRF = 1/62 + 1/61
+		// "a" is #1 in bm25, #2 in vector → RRF = 1/61 + 1/62
+		// They should be very close, with "a" and "b" at the top
+		const topIds = fused.slice(0, 2).map((r) => r.id);
+		expect(topIds).toContain("a");
+		expect(topIds).toContain("b");
+	});
+
+	test("atom ranked highly in both lists outranks atom in only one", () => {
+		const lists: RankedList[] = [
+			{
+				method: "bm25",
+				results: [
+					{ id: "both", score: 5.0 },
+					{ id: "bm25-only", score: 3.0 },
+				],
+			},
+			{
+				method: "vector",
+				results: [
+					{ id: "both", score: 0.95 },
+					{ id: "vector-only", score: 0.8 },
+				],
+			},
+		];
+
+		const fused = fuseResults(lists, 10);
+		expect(fused[0]?.id).toBe("both");
+		// "both" should score higher than either single-method atom
+		const bm25Only = fused.find((r) => r.id === "bm25-only");
+		expect(bm25Only).toBeDefined();
+		expect(fused[0]?.score).toBeGreaterThan(bm25Only?.score ?? 0);
+	});
+
+	test("handles atoms appearing in only one list", () => {
+		const lists: RankedList[] = [
+			{
+				method: "bm25",
+				results: [{ id: "only-bm25", score: 5.0 }],
+			},
+			{
+				method: "vector",
+				results: [{ id: "only-vector", score: 0.95 }],
+			},
+		];
+
+		const fused = fuseResults(lists, 10);
+		expect(fused.length).toBe(2);
+		const ids = fused.map((r) => r.id);
+		expect(ids).toContain("only-bm25");
+		expect(ids).toContain("only-vector");
+	});
+
+	test("handles empty lists", () => {
+		expect(fuseResults([], 10)).toEqual([]);
+		expect(fuseResults([{ method: "bm25", results: [] }], 10)).toEqual([]);
+	});
+
+	test("handles single-method mode", () => {
+		const lists: RankedList[] = [
+			{
+				method: "bm25",
+				results: [
+					{ id: "a", score: 5.0 },
+					{ id: "b", score: 3.0 },
+				],
+			},
+		];
+
+		const fused = fuseResults(lists, 10);
+		expect(fused.length).toBe(2);
+		expect(fused[0]?.id).toBe("a");
+		expect(fused[1]?.id).toBe("b");
+	});
+
+	test("respects top-k after fusion", () => {
+		const lists: RankedList[] = [
+			{
+				method: "bm25",
+				results: [
+					{ id: "a", score: 5.0 },
+					{ id: "b", score: 3.0 },
+					{ id: "c", score: 1.0 },
+				],
+			},
+		];
+
+		const fused = fuseResults(lists, 2);
+		expect(fused.length).toBe(2);
+	});
+
+	test("preserves per-method rank information", () => {
+		const lists: RankedList[] = [
+			{
+				method: "bm25",
+				results: [
+					{ id: "a", score: 5.0 },
+					{ id: "b", score: 3.0 },
+				],
+			},
+			{
+				method: "vector",
+				results: [
+					{ id: "b", score: 0.95 },
+					{ id: "a", score: 0.8 },
+				],
+			},
+		];
+
+		const fused = fuseResults(lists, 10);
+		const atomA = fused.find((r) => r.id === "a");
+		const atomB = fused.find((r) => r.id === "b");
+		expect(atomA).toBeDefined();
+		expect(atomB).toBeDefined();
+		if (!atomA || !atomB) return;
+		expect(atomA.ranks.bm25).toBe(1);
+		expect(atomA.ranks.vector).toBe(2);
+		expect(atomB.ranks.bm25).toBe(2);
+		expect(atomB.ranks.vector).toBe(1);
+	});
+});

--- a/engine/test/retrieve/index.test.ts
+++ b/engine/test/retrieve/index.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { atomToText } from "../../src/integrate/embedding-service";
+import type { VectorIndex } from "../../src/integrate/types";
+import { retrieve } from "../../src/retrieve/index";
+import { allFixtureAtoms } from "./fixtures/sample-atoms";
+
+/**
+ * Mock embeddings: 4-dim vectors with known similarity.
+ * Replication atoms → [1, 0, 0, 0] direction
+ * Industry atoms → [0, 1, 0, 0] direction
+ * Behavior atoms → [0, 0, 1, 0] direction
+ * Noise atoms → [0, 0, 0, 1] direction
+ */
+function makeMockEmbeddings(): VectorIndex {
+	return allFixtureAtoms.map((atom) => {
+		let embedding: number[];
+		if (atom.id.startsWith("dist-")) {
+			embedding = [0.9 + Math.random() * 0.1, 0.1, 0, 0];
+		} else if (atom.id.startsWith("ind-")) {
+			embedding = [0, 0.9 + Math.random() * 0.1, 0.1, 0];
+		} else if (atom.id.startsWith("beh-")) {
+			embedding = [0, 0.1, 0.9 + Math.random() * 0.1, 0];
+		} else {
+			embedding = [0, 0, 0.1, 0.9 + Math.random() * 0.1];
+		}
+		return {
+			atomId: atom.id,
+			text: atomToText(atom),
+			embedding,
+		};
+	});
+}
+
+describe("retrieve", () => {
+	const atoms = allFixtureAtoms;
+	const embeddings = makeMockEmbeddings();
+
+	test("runs hybrid search end-to-end with preloaded data", async () => {
+		const results = await retrieve({
+			query: "replication lag",
+			atoms,
+			embeddings,
+			queryEmbedding: [1, 0, 0, 0],
+			topK: 5,
+			method: "hybrid",
+		});
+
+		expect(results.length).toBe(5);
+		// Should have atom data, score, and ranks
+		expect(results[0]?.atom).toBeDefined();
+		expect(results[0]?.score).toBeGreaterThan(0);
+		expect(results[0]?.ranks).toBeDefined();
+	});
+
+	test("bm25-only mode does not require embeddings", async () => {
+		const results = await retrieve({
+			query: "replication lag",
+			atoms,
+			method: "bm25",
+			topK: 5,
+		});
+
+		expect(results.length).toBe(5);
+		// Top results should be dist-sys atoms
+		const topIds = results.slice(0, 3).map((r) => r.atom.id);
+		expect(topIds.some((id) => id.startsWith("dist-"))).toBe(true);
+		// vector rank should be null in bm25-only mode
+		expect(results[0]?.ranks.vector).toBeNull();
+	});
+
+	test("vector-only mode works with pre-computed query embedding", async () => {
+		const results = await retrieve({
+			query: "replication lag",
+			atoms,
+			embeddings,
+			queryEmbedding: [1, 0, 0, 0],
+			method: "vector",
+			topK: 5,
+		});
+
+		expect(results.length).toBe(5);
+		// Top results should be dist-sys atoms (aligned with [1,0,0,0])
+		expect(results[0]?.atom.id.startsWith("dist-")).toBe(true);
+		// bm25 rank should be null in vector-only mode
+		expect(results[0]?.ranks.bm25).toBeNull();
+	});
+
+	test("returns structured RetrievalResult with atom and ranks", async () => {
+		const results = await retrieve({
+			query: "feedback loop habit formation",
+			atoms,
+			embeddings,
+			queryEmbedding: [0, 0, 1, 0],
+			topK: 3,
+			method: "hybrid",
+		});
+
+		const first = results[0];
+		expect(first).toBeDefined();
+		if (!first) return;
+		expect(first.atom.id).toBeDefined();
+		expect(first.atom.frame).toBeDefined();
+		expect(first.atom.roles).toBeDefined();
+		expect(typeof first.score).toBe("number");
+		expect("bm25" in first.ranks).toBe(true);
+		expect("vector" in first.ranks).toBe(true);
+	});
+
+	test("handles missing embeddings gracefully (falls back to BM25)", async () => {
+		const results = await retrieve({
+			query: "replication lag",
+			atoms,
+			// no embeddings, no queryEmbedding
+			method: "hybrid",
+			topK: 5,
+		});
+
+		// Should still return results (BM25-only fallback)
+		expect(results.length).toBeGreaterThan(0);
+	});
+
+	test("respects topK", async () => {
+		const results = await retrieve({
+			query: "replication",
+			atoms,
+			method: "bm25",
+			topK: 2,
+		});
+		expect(results.length).toBe(2);
+	});
+});

--- a/engine/test/retrieve/integration.test.ts
+++ b/engine/test/retrieve/integration.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration tests — run retrieval against real graph data.
+ *
+ * These tests depend on engine/graph/ existing with processed book data.
+ * They verify retrieval quality on known queries where we can predict
+ * which atoms should rank highly.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { retrieve } from "../../src/retrieve/index";
+
+const graphDir = join(import.meta.dir, "../../graph");
+const hasGraph = existsSync(join(graphDir, "atoms.json"));
+
+describe.skipIf(!hasGraph)("retrieval integration (real data)", () => {
+	test("BM25 retrieves relevant atoms for 'replication lag'", async () => {
+		const results = await retrieve({
+			query: "replication lag",
+			method: "bm25",
+			graphDir,
+			topK: 10,
+		});
+
+		expect(results.length).toBe(10);
+		// Top results should come from DDIA (the book about distributed systems)
+		const topSources = results.slice(0, 5).map((r) => r.atom.source.title);
+		const hasDDIA = topSources.some((t) =>
+			t.includes("Designing Data-Intensive Applications"),
+		);
+		expect(hasDDIA).toBe(true);
+	});
+
+	test("BM25 retrieves relevant atoms for CJK query '行业生命周期'", async () => {
+		const results = await retrieve({
+			query: "行业生命周期",
+			method: "bm25",
+			graphDir,
+			topK: 10,
+		});
+
+		expect(results.length).toBe(10);
+		// Top results should come from the industry analysis book
+		const topSources = results.slice(0, 3).map((r) => r.atom.source.title);
+		const hasIndustry = topSources.some((t) =>
+			t.includes("如何快速了解一个行业"),
+		);
+		expect(hasIndustry).toBe(true);
+	});
+
+	test("BM25 and hybrid return different rankings for same query", async () => {
+		// Without embeddings API, hybrid falls back to BM25, so just test
+		// that the API works and returns results for both methods
+		const bm25 = await retrieve({
+			query: "consistency model",
+			method: "bm25",
+			graphDir,
+			topK: 5,
+		});
+
+		const hybrid = await retrieve({
+			query: "consistency model",
+			method: "hybrid",
+			graphDir,
+			topK: 5,
+		});
+
+		expect(bm25.length).toBeGreaterThan(0);
+		expect(hybrid.length).toBeGreaterThan(0);
+	});
+});

--- a/engine/test/retrieve/tokenizer.test.ts
+++ b/engine/test/retrieve/tokenizer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { tokenize, tokenizeWithFrequency } from "../../src/retrieve/tokenizer";
+
+describe("tokenize", () => {
+	test("lowercases and splits English text on non-alphanumeric chars", () => {
+		const tokens = tokenize("Replication Lag — the delay");
+		expect(tokens).toContain("replication");
+		expect(tokens).toContain("lag");
+		expect(tokens).toContain("delay");
+		// should not contain punctuation or empty strings
+		expect(tokens.every((t) => t.length > 0)).toBe(true);
+		expect(tokens.every((t) => /^[a-z0-9\u4e00-\u9fff]+$/.test(t))).toBe(true);
+	});
+
+	test("filters common English stopwords", () => {
+		const tokens = tokenize("the delay between a write and its reflection");
+		expect(tokens).not.toContain("the");
+		expect(tokens).not.toContain("between");
+		expect(tokens).not.toContain("a");
+		expect(tokens).not.toContain("and");
+		expect(tokens).not.toContain("its");
+		expect(tokens).toContain("delay");
+		expect(tokens).toContain("write");
+		expect(tokens).toContain("reflection");
+	});
+
+	test("handles CJK text with character bigrams", () => {
+		const tokens = tokenize("行业生命周期");
+		// "行业生命周期" → ["行业", "业生", "生命", "命周", "周期"]
+		expect(tokens).toContain("行业");
+		expect(tokens).toContain("生命");
+		expect(tokens).toContain("周期");
+		expect(tokens.length).toBe(5);
+	});
+
+	test("handles mixed EN/CJK text", () => {
+		const tokens = tokenize("渗透率 penetration rate 10%");
+		// Should have CJK bigrams and English words
+		expect(tokens).toContain("渗透");
+		expect(tokens).toContain("透率");
+		expect(tokens).toContain("penetration");
+		expect(tokens).toContain("rate");
+		// "10" could be included as a number token
+	});
+
+	test("returns empty array for empty string", () => {
+		expect(tokenize("")).toEqual([]);
+	});
+
+	test("returns empty array for stopwords-only input", () => {
+		expect(tokenize("the a an is")).toEqual([]);
+	});
+
+	test("handles single CJK character (no bigram possible)", () => {
+		const tokens = tokenize("人");
+		// Single char — can't form bigram, include as-is
+		expect(tokens).toEqual(["人"]);
+	});
+});
+
+describe("tokenizeWithFrequency", () => {
+	test("counts term frequency correctly", () => {
+		const freq = tokenizeWithFrequency(
+			"replication lag causes replication delay",
+		);
+		expect(freq.get("replication")).toBe(2);
+		expect(freq.get("lag")).toBe(1);
+		expect(freq.get("delay")).toBe(1);
+	});
+
+	test("counts CJK bigram frequency", () => {
+		const freq = tokenizeWithFrequency("行业分析行业");
+		// "行业分析行业" → ["行业", "业分", "分析", "析行", "行业"]
+		expect(freq.get("行业")).toBe(2);
+		expect(freq.get("分析")).toBe(1);
+	});
+});

--- a/engine/test/retrieve/vector-search.test.ts
+++ b/engine/test/retrieve/vector-search.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import type { VectorIndex } from "../../src/integrate/types";
+import { queryVectors } from "../../src/retrieve/vector-search";
+
+/**
+ * Small 4-dim vectors with known similarity relationships.
+ * Cosine sim: similar1 ≈ similar2 > unrelated
+ */
+const mockIndex: VectorIndex = [
+	{
+		atomId: "atom-a",
+		text: "replication lag definition",
+		embedding: [1, 0, 0, 0],
+	},
+	{
+		atomId: "atom-b",
+		text: "replication delay causes stale reads",
+		embedding: [0.9, 0.1, 0, 0], // similar to atom-a
+	},
+	{
+		atomId: "atom-c",
+		text: "habit formation feedback loop",
+		embedding: [0, 0, 1, 0], // orthogonal to a/b
+	},
+	{
+		atomId: "atom-d",
+		text: "industry lifecycle penetration rate",
+		embedding: [0, 0, 0, 1], // orthogonal to all above
+	},
+	{
+		atomId: "atom-e",
+		text: "another replication topic",
+		embedding: [0.8, 0.2, 0.1, 0], // somewhat similar to atom-a
+	},
+];
+
+describe("queryVectors", () => {
+	test("finds nearest neighbors by cosine similarity", () => {
+		const queryEmbedding = [1, 0, 0, 0]; // should match atom-a most
+		const results = queryVectors(queryEmbedding, mockIndex, 3);
+		expect(results[0]?.id).toBe("atom-a");
+		expect(results[0]?.score).toBeCloseTo(1.0, 4);
+	});
+
+	test("returns results sorted by descending similarity", () => {
+		const queryEmbedding = [1, 0, 0, 0];
+		const results = queryVectors(queryEmbedding, mockIndex, 5);
+		for (let i = 1; i < results.length; i++) {
+			expect(results[i - 1]?.score).toBeGreaterThanOrEqual(results[i]?.score);
+		}
+	});
+
+	test("respects top-k limit", () => {
+		const results = queryVectors([1, 0, 0, 0], mockIndex, 2);
+		expect(results.length).toBe(2);
+	});
+
+	test("handles empty embedding index", () => {
+		const results = queryVectors([1, 0, 0, 0], [], 5);
+		expect(results).toEqual([]);
+	});
+
+	test("handles query embedding of all zeros", () => {
+		const results = queryVectors([0, 0, 0, 0], mockIndex, 5);
+		// cosine similarity with zero vector = 0, so all scores should be 0
+		for (const r of results) {
+			expect(r.score).toBe(0);
+		}
+	});
+
+	test("correctly identifies orthogonal vectors as dissimilar", () => {
+		// Query aligned with atom-c (habit formation)
+		const results = queryVectors([0, 0, 1, 0], mockIndex, 5);
+		expect(results[0]?.id).toBe("atom-c");
+		expect(results[0]?.score).toBeCloseTo(1.0, 4);
+		// atom-a should have ~0 similarity
+		const atomA = results.find((r) => r.id === "atom-a");
+		expect(atomA?.score).toBeCloseTo(0, 4);
+	});
+});


### PR DESCRIPTION
## Summary

Three features backing resume claims, built on top of the existing Learn pipeline:

- **Hybrid retrieval engine** — BM25 lexical search + vector similarity search + Reciprocal Rank Fusion. Supports EN and CJK (bigram tokenization). CLI: `bun run src/run-retrieve.ts "query"`
- **Evaluation framework** — 9 quality checks across 3 layers (structural, schema, semantic). Detected issues in 39.7% of 4,101 atoms. CLI: `bun run src/run-eval.ts graph/atoms.json`
- **Checkpoint recovery** — Auto-saves pipeline state after each stage. `--resume` picks up from last completed stage. `--checkpoint-status` shows progress.

### Implementation stats
- ~840 lines of new implementation across 11 source files
- ~950 lines of tests across 10 test files + 2 fixture files
- 95 new tests (325 total), all passing
- Lint clean (biome)

## Test plan
- [ ] `cd engine && bun test` — 325 tests passing
- [ ] `cd engine && bun run typecheck` — no type errors
- [ ] `bun run src/run-retrieve.ts "replication lag" --method bm25 --verbose` — returns ranked DDIA atoms
- [ ] `bun run src/run-retrieve.ts "行业生命周期" --method bm25` — returns Chinese industry atoms
- [ ] `bun run src/run-eval.ts graph/atoms.json` — shows quality report
- [ ] `bun run src/run-eval.ts --compare output/designing-data-intensive-applications.json graph/atoms.json` — shows before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)