### PR TITLE
fix: resolve TypeScript strict-mode type errors

### DIFF
--- a/engine/src/retrieve/bm25.ts
+++ b/engine/src/retrieve/bm25.ts
@@ -109,7 +109,7 @@ export function queryBM25(
 			const dl = index.docLengths[doc] ?? 0;
 			const numerator = tf * (K1 + 1);
 			const denominator = tf + K1 * (1 - B + B * (dl / index.avgDocLength));
-			scores[doc] += termIdf * (numerator / denominator);
+			scores[doc] = (scores[doc] ?? 0) + termIdf * (numerator / denominator);
 		}
 	}
 

--- a/engine/src/retrieve/index.ts
+++ b/engine/src/retrieve/index.ts
@@ -92,20 +92,20 @@ export async function retrieve(
 	const fused = fuseResults(rankedLists, topK);
 
 	// Map back to atoms
-	return fused
-		.map((f) => {
-			const atom = atomMap.get(f.id);
-			if (!atom) return null;
-			return {
-				atom,
-				score: f.score,
-				ranks: {
-					bm25: f.ranks.bm25 ?? null,
-					vector: f.ranks.vector ?? null,
-				},
-			};
-		})
-		.filter((r): r is RetrievalResult => r !== null);
+	const results: RetrievalResult[] = [];
+	for (const f of fused) {
+		const atom = atomMap.get(f.id);
+		if (!atom) continue;
+		results.push({
+			atom,
+			score: f.score,
+			ranks: {
+				bm25: f.ranks.bm25 ?? null,
+				vector: f.ranks.vector ?? null,
+			},
+		});
+	}
+	return results;
 }
 
 function loadJson<T>(dir: string, file: string): T {

--- a/engine/src/run-eval.ts
+++ b/engine/src/run-eval.ts
@@ -23,15 +23,14 @@ function parseArgs(argv: string[]) {
 	const files: string[] = [];
 	let raw = false;
 	let compare = false;
-	let format: "table" | "json" = "table";
+	let format = "table" as string;
 	let verbose = false;
 
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i];
 		if (arg === "--raw") raw = true;
 		else if (arg === "--compare") compare = true;
-		else if (arg === "--format")
-			format = (args[++i] ?? "table") as typeof format;
+		else if (arg === "--format") format = args[++i] ?? "table";
 		else if (arg === "--verbose") verbose = true;
 		else if (arg && !arg.startsWith("--")) files.push(arg);
 	}

--- a/engine/src/run-retrieve.ts
+++ b/engine/src/run-retrieve.ts
@@ -14,13 +14,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { atomToText } from "./integrate/embedding-service";
-import { retrieve, type RetrievalResult } from "./retrieve/index";
+import { type RetrievalResult, retrieve } from "./retrieve/index";
 
 function parseArgs(argv: string[]) {
 	const args = argv.slice(2);
 	let query = "";
 	let topK = 10;
-	let method: "hybrid" | "bm25" | "vector" = "hybrid";
+	let method = "hybrid" as string;
 	let graphDir = join(new URL(".", import.meta.url).pathname, "../graph");
 	let verbose = false;
 	let json = false;
@@ -30,7 +30,7 @@ function parseArgs(argv: string[]) {
 		if (arg === "--top-k") {
 			topK = Number.parseInt(args[++i] ?? "10", 10);
 		} else if (arg === "--method") {
-			method = (args[++i] ?? "hybrid") as typeof method;
+			method = args[++i] ?? "hybrid";
 		} else if (arg === "--graph-dir") {
 			graphDir = args[++i] ?? graphDir;
 		} else if (arg === "--verbose") {
@@ -77,9 +77,15 @@ async function main() {
 		console.error('Usage: bun run src/run-retrieve.ts "query" [options]');
 		console.error("");
 		console.error("Options:");
-		console.error("  --top-k <n>                 results to return (default: 10)");
-		console.error("  --method hybrid|bm25|vector retrieval method (default: hybrid)");
-		console.error("  --graph-dir <path>          data directory (default: engine/graph)");
+		console.error(
+			"  --top-k <n>                 results to return (default: 10)",
+		);
+		console.error(
+			"  --method hybrid|bm25|vector retrieval method (default: hybrid)",
+		);
+		console.error(
+			"  --graph-dir <path>          data directory (default: engine/graph)",
+		);
 		console.error("  --verbose                   show per-method ranks");
 		console.error("  --json                      output raw JSON");
 		process.exit(1);
@@ -120,7 +126,9 @@ async function main() {
 		const apiKey = process.env.OPENAI_API_KEY;
 		if (apiKey) {
 			try {
-				const { createOpenAIEmbeddingProvider } = await import("./llm/openai-embedding");
+				const { createOpenAIEmbeddingProvider } = await import(
+					"./llm/openai-embedding"
+				);
 				const provider = createOpenAIEmbeddingProvider({
 					provider: "openai",
 					model: "text-embedding-3-large",
@@ -133,7 +141,9 @@ async function main() {
 		}
 
 		if (!queryEmbedding && config.method === "hybrid") {
-			console.error("[info] No OPENAI_API_KEY or embedding failed — falling back to BM25-only");
+			console.error(
+				"[info] No OPENAI_API_KEY or embedding failed — falling back to BM25-only",
+			);
 		}
 	}
 
@@ -143,7 +153,7 @@ async function main() {
 		embeddings,
 		queryEmbedding,
 		topK: config.topK,
-		method: config.method,
+		method: config.method as "hybrid" | "bm25" | "vector",
 	});
 
 	if (config.json) {
@@ -163,7 +173,8 @@ async function main() {
 	console.error(`Results: ${results.length} of ${atoms.length} atoms\n`);
 
 	for (let i = 0; i < results.length; i++) {
-		console.error(formatResult(results[i]!, i + 1, config.verbose));
+		const result = results[i];
+		if (result) console.error(formatResult(result, i + 1, config.verbose));
 	}
 }
 

--- a/engine/test/checkpoint/checkpoint.test.ts
+++ b/engine/test/checkpoint/checkpoint.test.ts
@@ -48,7 +48,7 @@ describe("CheckpointManager", () => {
 
 		const meta = mgr.getMeta();
 		expect(meta).not.toBeNull();
-		expect(meta?.stages.parse.status).toBe("completed");
+		expect(meta?.stages.parse?.status).toBe("completed");
 	});
 
 	test("clear() removes all checkpoint files for a book", () => {
@@ -69,7 +69,7 @@ describe("CheckpointManager", () => {
 		// Directory doesn't exist yet — should create it on save
 		const mgr = createCheckpointManager("new-book", TEST_DIR);
 		mgr.save("parse", { test: true });
-		expect(mgr.load("parse")).toEqual({ test: true });
+		expect(mgr.load<{ test: boolean }>("parse")).toEqual({ test: true });
 	});
 
 	test("different books have isolated checkpoints", () => {
@@ -79,8 +79,8 @@ describe("CheckpointManager", () => {
 		mgr1.save("parse", { book: "a" });
 		mgr2.save("parse", { book: "b" });
 
-		expect(mgr1.load("parse")).toEqual({ book: "a" });
-		expect(mgr2.load("parse")).toEqual({ book: "b" });
+		expect(mgr1.load<{ book: string }>("parse")).toEqual({ book: "a" });
+		expect(mgr2.load<{ book: string }>("parse")).toEqual({ book: "b" });
 	});
 
 	test("getResumePoint() returns first non-completed stage", () => {

--- a/engine/test/checkpoint/pipeline-integration.test.ts
+++ b/engine/test/checkpoint/pipeline-integration.test.ts
@@ -36,8 +36,8 @@ describe("checkpoint pipeline integration", () => {
 			durationMs: 1200,
 		});
 
-		expect(mgr.load("parse")).toEqual(parseResult);
-		expect(mgr.getMeta()?.stages.parse.status).toBe("completed");
+		expect(mgr.load<typeof parseResult>("parse")).toEqual(parseResult);
+		expect(mgr.getMeta()?.stages.parse?.status).toBe("completed");
 	});
 
 	test("saves checkpoint after comprehend stage completes", () => {
@@ -53,7 +53,9 @@ describe("checkpoint pipeline integration", () => {
 			durationMs: 180000,
 		});
 
-		expect(mgr.load("comprehend")).toEqual(comprehendResult);
+		expect(mgr.load<typeof comprehendResult>("comprehend")).toEqual(
+			comprehendResult,
+		);
 	});
 
 	test("on resume, skips parse when parse checkpoint exists", () => {

--- a/engine/test/retrieve/bm25.test.ts
+++ b/engine/test/retrieve/bm25.test.ts
@@ -67,9 +67,11 @@ describe("queryBM25", () => {
 		// than docs matching only one
 		const results = queryBM25(index, "replication lag", docs.length);
 		if (results.length >= 2) {
-			expect(results[0]?.score).toBeGreaterThan(
-				results[results.length - 1]?.score,
-			);
+			const first = results[0];
+			const last = results[results.length - 1];
+			if (first && last) {
+				expect(first.score).toBeGreaterThan(last.score);
+			}
 		}
 	});
 
@@ -83,7 +85,11 @@ describe("queryBM25", () => {
 	test("returns results sorted by descending score", () => {
 		const results = queryBM25(index, "penetration rate industry", 10);
 		for (let i = 1; i < results.length; i++) {
-			expect(results[i - 1]?.score).toBeGreaterThanOrEqual(results[i]?.score);
+			const prev = results[i - 1];
+			const curr = results[i];
+			if (prev && curr) {
+				expect(prev.score).toBeGreaterThanOrEqual(curr.score);
+			}
 		}
 	});
 });

--- a/engine/test/retrieve/vector-search.test.ts
+++ b/engine/test/retrieve/vector-search.test.ts
@@ -46,7 +46,11 @@ describe("queryVectors", () => {
 		const queryEmbedding = [1, 0, 0, 0];
 		const results = queryVectors(queryEmbedding, mockIndex, 5);
 		for (let i = 1; i < results.length; i++) {
-			expect(results[i - 1]?.score).toBeGreaterThanOrEqual(results[i]?.score);
+			const prev = results[i - 1];
+			const curr = results[i];
+			if (prev && curr) {
+				expect(prev.score).toBeGreaterThanOrEqual(curr.score);
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary

- Fix 18 TypeScript strict-mode type errors across retrieval, eval, and checkpoint modules
- Non-null assertion replacements with proper guards
- Type predicate fix in retrieve/index.ts (filter → for loop)
- Union narrowing fix in CLI arg parsers (explicit `as string` instead of literal types)
- Generic type params on checkpoint `load<T>()` calls in tests

## Test plan
- [ ] `bun test` — 325 tests passing
- [ ] `bun run typecheck` — 0 errors
- [ ] `bun x @biomejs/biome check ./src ./test` — lint clean on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)