### PR TITLE
chore: fix all 29 pre-existing lint errors

### DIFF
--- a/engine/src/integrate/domain-normalizer.ts
+++ b/engine/src/integrate/domain-normalizer.ts
@@ -34,8 +34,7 @@ export async function buildDomainMap(
 	domainCounts: Map<string, number>,
 	provider: EmbeddingProvider,
 ): Promise<DomainMap> {
-	const domains = [...domainCounts.entries()]
-		.sort((a, b) => b[1] - a[1]); // most frequent first
+	const domains = [...domainCounts.entries()].sort((a, b) => b[1] - a[1]); // most frequent first
 
 	if (domains.length === 0) {
 		return { mapping: new Map(), canonicals: new Map() };
@@ -53,7 +52,9 @@ export async function buildDomainMap(
 	for (let i = 0; i < domains.length; i++) {
 		if (assigned.has(i)) continue;
 
-		const [centerName, centerCount] = domains[i]!;
+		const entry = domains[i];
+		if (!entry) continue;
+		const [centerName, centerCount] = entry;
 		const centerEmb = embeddings[i];
 		if (!centerEmb) continue;
 
@@ -70,7 +71,9 @@ export async function buildDomainMap(
 
 			const sim = cosineSimilarity(centerEmb, candidateEmb);
 			if (sim >= DOMAIN_MERGE_THRESHOLD) {
-				const [candidateName, candidateCount] = domains[j]!;
+				const candidate = domains[j];
+				if (!candidate) continue;
+				const [candidateName, candidateCount] = candidate;
 				assigned.add(j);
 				mapping.set(candidateName, centerName);
 				totalCount += candidateCount;
@@ -87,9 +90,6 @@ export async function buildDomainMap(
  * Normalize a domain string using the domain map.
  * Returns the canonical domain, or the original if not in the map.
  */
-export function normalizeDomain(
-	domain: string,
-	domainMap: DomainMap,
-): string {
+export function normalizeDomain(domain: string, domainMap: DomainMap): string {
 	return domainMap.mapping.get(domain) ?? domain;
 }

--- a/engine/src/integrate/entity-resolver.ts
+++ b/engine/src/integrate/entity-resolver.ts
@@ -7,9 +7,9 @@
 import type { CandidateAtom } from "../extract/types";
 import type { EmbeddingProvider } from "../llm/embedding-types";
 import type { LLMProvider } from "../llm/types";
-import { cosineSimilarity } from "./embedding-service";
 import { buildDomainMap, normalizeDomain } from "./domain-normalizer";
 import type { DomainMap } from "./domain-normalizer";
+import { cosineSimilarity } from "./embedding-service";
 import { entityDisambiguationPrompt } from "./prompts";
 import type { Entity, EntityIndex, EntityMention, VectorIndex } from "./types";
 
@@ -54,7 +54,10 @@ export interface ResolveResult {
 	};
 }
 
-export function extractMentions(atoms: CandidateAtom[], domainMap?: DomainMap): EntityMention[] {
+export function extractMentions(
+	atoms: CandidateAtom[],
+	domainMap?: DomainMap,
+): EntityMention[] {
 	const mentions: EntityMention[] = [];
 
 	for (const atom of atoms) {
@@ -62,7 +65,9 @@ export function extractMentions(atoms: CandidateAtom[], domainMap?: DomainMap): 
 		if (!entityRoles) continue;
 
 		const rawDomain = atom.domain[0] ?? "untagged";
-		const domain = domainMap ? normalizeDomain(rawDomain, domainMap) : rawDomain;
+		const domain = domainMap
+			? normalizeDomain(rawDomain, domainMap)
+			: rawDomain;
 
 		for (const role of entityRoles) {
 			const value = atom.roles[role];
@@ -198,7 +203,9 @@ export async function resolveEntities(
 
 	console.error(`[integrate] Normalizing ${domainCounts.size} domains...`);
 	const domainMap = await buildDomainMap(domainCounts, embeddingProvider);
-	console.error(`[integrate] Collapsed to ${domainMap.canonicals.size} canonical domains`);
+	console.error(
+		`[integrate] Collapsed to ${domainMap.canonicals.size} canonical domains`,
+	);
 
 	// Step 1: Extract mentions from new atoms (with normalized domains)
 	const mentions = extractMentions(newAtoms, domainMap);
@@ -316,14 +323,14 @@ export async function resolveEntities(
 
 		// Check if this merges into an existing entity
 		// Normalize existing entity domain for comparison
-		const existingEntity = Object.values(entities).find(
-			(e) => {
-				const eDomain = normalizeDomain(e.domain, domainMap);
-				return eDomain === domain &&
-					(e.canonicalName.toLowerCase() === canonicalName ||
-						e.aliases.some((a) => a.toLowerCase() === canonicalName));
-			},
-		);
+		const existingEntity = Object.values(entities).find((e) => {
+			const eDomain = normalizeDomain(e.domain, domainMap);
+			return (
+				eDomain === domain &&
+				(e.canonicalName.toLowerCase() === canonicalName ||
+					e.aliases.some((a) => a.toLowerCase() === canonicalName))
+			);
+		});
 
 		if (existingEntity) {
 			existingEntity.atomIds = [

--- a/engine/src/run-integrate.ts
+++ b/engine/src/run-integrate.ts
@@ -7,7 +7,13 @@
  * Reads all engine/output/*.json files and runs Integrate on each book
  * incrementally. No Parse/Comprehend/Extract — just the graph construction.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import type { CandidateAtom } from "./extract/types";
 import { integrate } from "./integrate/index";
@@ -67,13 +73,27 @@ async function main() {
 		});
 		const elapsed = ((Date.now() - start) / 1000).toFixed(1);
 
-		console.error(`  ${elapsed}s — ${graph.stats.totalEntities} entities, ${graph.stats.reinforcements} reinforcements, ${graph.stats.contradictions} contradictions`);
+		console.error(
+			`  ${elapsed}s — ${graph.stats.totalEntities} entities, ${graph.stats.reinforcements} reinforcements, ${graph.stats.contradictions} contradictions`,
+		);
 
 		// Save after each book (crash recovery)
-		writeFileSync(join(GRAPH_DIR, "atoms.json"), JSON.stringify(graph.atoms, null, 2));
-		writeFileSync(join(GRAPH_DIR, "entities.json"), JSON.stringify(graph.entities, null, 2));
-		writeFileSync(join(GRAPH_DIR, "graph.json"), JSON.stringify(graph.graph, null, 2));
-		writeFileSync(join(GRAPH_DIR, "embeddings.json"), JSON.stringify(graph.embeddings));
+		writeFileSync(
+			join(GRAPH_DIR, "atoms.json"),
+			JSON.stringify(graph.atoms, null, 2),
+		);
+		writeFileSync(
+			join(GRAPH_DIR, "entities.json"),
+			JSON.stringify(graph.entities, null, 2),
+		);
+		writeFileSync(
+			join(GRAPH_DIR, "graph.json"),
+			JSON.stringify(graph.graph, null, 2),
+		);
+		writeFileSync(
+			join(GRAPH_DIR, "embeddings.json"),
+			JSON.stringify(graph.embeddings),
+		);
 	}
 
 	if (!graph) {
@@ -86,7 +106,9 @@ async function main() {
 	console.error("INTEGRATION COMPLETE");
 	console.error(`${"═".repeat(60)}`);
 	console.error(`  Atoms:          ${graph.stats.totalAtoms}`);
-	console.error(`  Entities:       ${graph.stats.totalEntities} (${graph.stats.newEntities} new, ${graph.stats.mergedEntities} merged)`);
+	console.error(
+		`  Entities:       ${graph.stats.totalEntities} (${graph.stats.newEntities} new, ${graph.stats.mergedEntities} merged)`,
+	);
 	console.error(`  Reinforcements: ${graph.stats.reinforcements}`);
 	console.error(`  Contradictions: ${graph.stats.contradictions}`);
 	console.error(`  Extensions:     ${graph.stats.extensions}`);

--- a/engine/src/visualize-graph.ts
+++ b/engine/src/visualize-graph.ts
@@ -38,8 +38,7 @@ function main() {
 	for (const a of atoms) {
 		frameCounts[a.frame] = (frameCounts[a.frame] ?? 0) + 1;
 	}
-	const topFrames = Object.entries(frameCounts)
-		.sort((a, b) => b[1] - a[1]);
+	const topFrames = Object.entries(frameCounts).sort((a, b) => b[1] - a[1]);
 
 	// Edge stats
 	const edgeTypes: Record<string, number> = {};
@@ -159,7 +158,12 @@ ${topDomains
 ${bigEntities
 	.map(
 		(e) =>
-			`<tr><td><strong>${escHtml(e.canonicalName)}</strong></td><td><span class="tag">${escHtml(e.domain)}</span></td><td>${e.atomIds.length}</td><td>${e.aliases.slice(0, 3).map((a) => `<span class="tag purple">${escHtml(a.slice(0, 30))}</span>`).join(" ")}</td></tr>`,
+			`<tr><td><strong>${escHtml(e.canonicalName)}</strong></td><td><span class="tag">${escHtml(e.domain)}</span></td><td>${e.atomIds.length}</td><td>${e.aliases
+				.slice(0, 3)
+				.map(
+					(a) => `<span class="tag purple">${escHtml(a.slice(0, 30))}</span>`,
+				)
+				.join(" ")}</td></tr>`,
 	)
 	.join("\n")}
 </table>

--- a/engine/test/integrate/embedding-service.test.ts
+++ b/engine/test/integrate/embedding-service.test.ts
@@ -149,16 +149,17 @@ describe("embedAtoms", () => {
 	test("skips already-cached atoms", async () => {
 		const provider = createMockEmbeddingProvider();
 		const atoms = bookAAtoms.slice(0, 2);
+		const firstAtomId = atoms[0]?.id ?? "missing";
 		const existingCache = [
 			{
-				atomId: atoms[0]!.id,
+				atomId: firstAtomId,
 				text: "cached text",
 				embedding: new Array(provider.dimensions).fill(0),
 			},
 		];
 		const result = await embedAtoms(atoms, provider, existingCache);
 		expect(result).toHaveLength(2);
-		expect(result.find((e) => e.atomId === atoms[0]!.id)?.text).toBe(
+		expect(result.find((e) => e.atomId === firstAtomId)?.text).toBe(
 			"cached text",
 		);
 	});

--- a/engine/test/integrate/entity-resolver.test.ts
+++ b/engine/test/integrate/entity-resolver.test.ts
@@ -36,7 +36,7 @@ describe("extractMentions", () => {
 			(m) => m.role === "term" && m.text === "replication lag",
 		);
 		expect(defMention).toBeDefined();
-		expect(defMention!.frame).toBe("definition");
+		expect(defMention?.frame).toBe("definition");
 	});
 
 	test("extracts cause and effect from causal atoms", () => {
@@ -55,13 +55,13 @@ describe("extractMentions", () => {
 
 	test("uses first domain element as primary domain", () => {
 		const mentions = extractMentions(bookAAtoms);
-		expect(mentions[0]!.domain).toBe("distributed systems");
+		expect(mentions[0]?.domain).toBe("distributed systems");
 	});
 
 	test("atoms with no domain get 'untagged'", () => {
 		const atom = makeAtom({ domain: [] });
 		const mentions = extractMentions([atom]);
-		expect(mentions[0]!.domain).toBe("untagged");
+		expect(mentions[0]?.domain).toBe("untagged");
 	});
 
 	test("truncates long mention text to 60 chars", () => {
@@ -73,7 +73,7 @@ describe("extractMentions", () => {
 			},
 		});
 		const mentions = extractMentions([atom]);
-		expect(mentions[0]!.text.length).toBeLessThanOrEqual(60);
+		expect(mentions[0]?.text.length).toBeLessThanOrEqual(60);
 	});
 });
 
@@ -89,7 +89,7 @@ describe("clusterMentions", () => {
 		);
 		expect(repLagCluster).toBeDefined();
 		expect(
-			repLagCluster!.mentions.filter((m) => m.normalized === "replication lag")
+			repLagCluster?.mentions.filter((m) => m.normalized === "replication lag")
 				.length,
 		).toBeGreaterThan(1);
 	});
@@ -135,7 +135,7 @@ describe("resolveEntities — full pipeline", () => {
 			e.canonicalName.toLowerCase().includes("replication lag"),
 		);
 		expect(repLagEntity).toBeDefined();
-		expect(repLagEntity!.atomIds.length).toBeGreaterThan(1);
+		expect(repLagEntity?.atomIds.length).toBeGreaterThan(1);
 	});
 
 	test("incremental: new mentions merge into existing entities", async () => {

--- a/engine/test/integrate/fixtures/mock-embeddings.ts
+++ b/engine/test/integrate/fixtures/mock-embeddings.ts
@@ -58,7 +58,8 @@ export const MOCK_VECTORS: Record<string, number[]> = {
 function hashToVector(text: string): number[] {
 	const vec = new Array(MOCK_DIMENSIONS).fill(0) as number[];
 	for (let i = 0; i < text.length; i++) {
-		vec[i % MOCK_DIMENSIONS]! += text.charCodeAt(i) / 1000;
+		const idx = i % MOCK_DIMENSIONS;
+		vec[idx] = (vec[idx] ?? 0) + text.charCodeAt(i) / 1000;
 	}
 	// Normalize
 	const mag = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));

--- a/engine/test/integrate/graph-builder.test.ts
+++ b/engine/test/integrate/graph-builder.test.ts
@@ -10,10 +10,10 @@ describe("finalizeAtoms", () => {
 	test("promotes CandidateAtom to Atom with empty cross-references", () => {
 		const atom = makeAtom({ id: "test-1" });
 		const [finalized] = finalizeAtoms([atom], {}, []);
-		expect(finalized!.entityRefs).toEqual([]);
-		expect(finalized!.reinforcedBy).toEqual([]);
-		expect(finalized!.contradictedBy).toEqual([]);
-		expect(finalized!.extendedBy).toEqual([]);
+		expect(finalized?.entityRefs).toEqual([]);
+		expect(finalized?.reinforcedBy).toEqual([]);
+		expect(finalized?.contradictedBy).toEqual([]);
+		expect(finalized?.extendedBy).toEqual([]);
 	});
 
 	test("populates entityRefs from entity index", () => {
@@ -29,7 +29,7 @@ describe("finalizeAtoms", () => {
 			},
 		};
 		const [finalized] = finalizeAtoms([atom], entities, []);
-		expect(finalized!.entityRefs).toEqual(["entity:foo"]);
+		expect(finalized?.entityRefs).toEqual(["entity:foo"]);
 	});
 
 	test("populates reinforcedBy from relations", () => {
@@ -46,10 +46,12 @@ describe("finalizeAtoms", () => {
 		];
 
 		const finalized = finalizeAtoms([atomA, atomB], {}, relations);
-		const fA = finalized.find((a) => a.id === "a")!;
-		const fB = finalized.find((a) => a.id === "b")!;
-		expect(fA.reinforcedBy).toContain("b");
-		expect(fB.reinforcedBy).toContain("a");
+		const fA = finalized.find((a) => a.id === "a");
+		const fB = finalized.find((a) => a.id === "b");
+		expect(fA).toBeDefined();
+		expect(fB).toBeDefined();
+		expect(fA?.reinforcedBy).toContain("b");
+		expect(fB?.reinforcedBy).toContain("a");
 	});
 
 	test("boosts confidence for reinforced atoms (capped at 1.0)", () => {
@@ -79,7 +81,7 @@ describe("finalizeAtoms", () => {
 		];
 		const [finalized] = finalizeAtoms([atom], {}, relations);
 		// 0.9 + 0.05 * 3 = 1.05 → capped at 1.0
-		expect(finalized!.confidence).toBe(1.0);
+		expect(finalized?.confidence).toBe(1.0);
 	});
 
 	test("populates contradictedBy from relations", () => {
@@ -95,8 +97,8 @@ describe("finalizeAtoms", () => {
 			},
 		];
 		const finalized = finalizeAtoms([atomA, atomB], {}, relations);
-		expect(finalized.find((a) => a.id === "a")!.contradictedBy).toContain("b");
-		expect(finalized.find((a) => a.id === "b")!.contradictedBy).toContain("a");
+		expect(finalized.find((a) => a.id === "a")?.contradictedBy).toContain("b");
+		expect(finalized.find((a) => a.id === "b")?.contradictedBy).toContain("a");
 	});
 
 	test("populates extendedBy from relations", () => {
@@ -112,8 +114,8 @@ describe("finalizeAtoms", () => {
 			},
 		];
 		const finalized = finalizeAtoms([atomA, atomB], {}, relations);
-		expect(finalized.find((a) => a.id === "a")!.extendedBy).toContain("b");
-		expect(finalized.find((a) => a.id === "b")!.extendedBy).toContain("a");
+		expect(finalized.find((a) => a.id === "a")?.extendedBy).toContain("b");
+		expect(finalized.find((a) => a.id === "b")?.extendedBy).toContain("a");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Fix all 29 lint errors in the integrate module and its tests
- Non-null assertions replaced with explicit guards or optional chaining
- Import sorting, formatting fixes in entity-resolver, visualize-graph, run-integrate
- Full repo now lint clean: 103 files, 0 errors

## Test plan
- [ ] `bun test` — 325 tests passing
- [ ] `bun run typecheck` — 0 errors
- [ ] `bun run lint` — 0 errors (entire repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)