### PR TITLE
docs(apply): add query understanding prompt and KX export mapping

### DIFF
--- a/design/08-apply-pipeline.md
+++ b/design/08-apply-pipeline.md
@@ -407,6 +407,422 @@ Add the LLM-powered query planner to replace manual CLI flags.
 
 ---
 
+## Appendix A: Query Understanding Prompt
+
+The query understanding stage uses a cheap model (Haiku tier) with
+one call. The prompt constrains the output to the graph's actual
+inventory — the model can only target domains, entities, and frame
+types that exist.
+
+### System Prompt
+
+```
+You are a query planner for a knowledge retrieval system. Given a
+user's question and an inventory of available knowledge, produce a
+structured query plan.
+
+You will receive:
+- The user's question
+- An inventory of available domains, entities, and frame types
+  with their counts
+
+Respond with a JSON object using EXACTLY these field names (camelCase):
+
+{
+  "intent": "<what the user is trying to do>",
+  "analysisType": "<type of analysis needed>",
+  "targetDomains": ["<domain1>", "<domain2>"],
+  "targetFrameTypes": ["<frameType1>", "<frameType2>"],
+  "targetEntities": ["<entity1>", "<entity2>"],
+  "weights": {
+    "domainMatch": 0.0-1.0,
+    "frameTypeMatch": 0.0-1.0,
+    "entityMatch": 0.0-1.0
+  }
+}
+
+Rules:
+1. Only use domains, entities, and frame types from the inventory.
+   Do NOT invent domains or entities that don't exist.
+2. Select 1-5 target domains (most relevant to the question).
+3. Select 2-6 target frame types based on what the question needs:
+   - "How do I..." → procedure, heuristic
+   - "What is..." → definition, has_property
+   - "Compare..." → method_comparison, evaluation_matrix
+   - "Why does..." → causal, causal_chain
+   - "Evaluate..." → evaluation_matrix, heuristic, principle
+   - "What are the risks..." → deviation, threshold
+4. Select 2-8 target entities (concepts the question is about).
+5. Set weights based on query specificity:
+   - Broad questions → higher domainMatch (cast a wide net)
+   - Specific questions → higher entityMatch (precise retrieval)
+   - "How to" questions → higher frameTypeMatch (method-focused)
+
+IMPORTANT: Use camelCase field names exactly as shown. Do NOT use
+snake_case. Respond with valid JSON only.
+```
+
+### User Prompt
+
+```
+Question: "{query}"
+
+{scope constraints if provided via CLI flags}
+
+--- Available Knowledge Inventory ---
+
+Domains ({count} total):
+{domain_name} ({atom_count} atoms)
+...
+
+Entities ({count} total):
+{entity_name} [aliases: {alias1}, {alias2}] — domain: {domain}
+...
+
+Frame Types ({count} total):
+{frame_type_name} ({count} atoms) — {description}
+...
+```
+
+### Response Schema
+
+```typescript
+function getQueryPlanSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      intent: { type: "string" },
+      analysisType: { type: "string" },
+      targetDomains: {
+        type: "array",
+        items: { type: "string" },
+      },
+      targetFrameTypes: {
+        type: "array",
+        items: { type: "string" },
+      },
+      targetEntities: {
+        type: "array",
+        items: { type: "string" },
+      },
+      weights: {
+        type: "object",
+        properties: {
+          domainMatch: { type: "number" },
+          frameTypeMatch: { type: "number" },
+          entityMatch: { type: "number" },
+        },
+        required: ["domainMatch", "frameTypeMatch", "entityMatch"],
+      },
+    },
+    required: [
+      "intent",
+      "analysisType",
+      "targetDomains",
+      "targetFrameTypes",
+      "targetEntities",
+      "weights",
+    ],
+  };
+}
+```
+
+### Inventory Construction
+
+The inventory is pre-computed once when the graph is loaded. It's a
+compact summary — not the full graph — small enough to fit in a
+cheap model's context.
+
+```typescript
+function buildInventory(graph: KnowledgeGraph): GraphInventory {
+  const domainCounts = new Map<string, number>();
+  const frameTypeCounts = new Map<string, number>();
+
+  for (const atom of graph.atoms) {
+    for (const d of atom.domain) {
+      domainCounts.set(d, (domainCounts.get(d) ?? 0) + 1);
+    }
+    frameTypeCounts.set(
+      atom.frame,
+      (frameTypeCounts.get(atom.frame) ?? 0) + 1,
+    );
+  }
+
+  return {
+    domains: [...domainCounts.entries()]
+      .map(([name, atomCount]) => ({ name, atomCount }))
+      .sort((a, b) => b.atomCount - a.atomCount),
+    entities: Object.values(graph.entities)
+      .map(e => ({
+        name: e.canonicalName,
+        aliases: e.aliases,
+        domain: e.domain,
+      })),
+    frameTypes: [...frameTypeCounts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count),
+    sources: extractSourceList(graph.atoms),
+  };
+}
+```
+
+### Field Normalization
+
+LLMs return snake_case despite instructions. Normalize:
+
+```typescript
+function normalizeQueryPlan(raw: Record<string, unknown>): QueryPlan {
+  return {
+    intent: (raw.intent ?? raw["intent"]) as string,
+    analysisType: (raw.analysisType ?? raw["analysis_type"]) as string,
+    targetDomains: (raw.targetDomains ?? raw["target_domains"]) as string[],
+    targetFrameTypes: (raw.targetFrameTypes ?? raw["target_frame_types"]) as string[],
+    targetEntities: (raw.targetEntities ?? raw["target_entities"]) as string[],
+    weights: normalizeWeights(raw.weights ?? raw["weights"]),
+  };
+}
+```
+
+---
+
+## Appendix B: KX Export Mapping
+
+How ContextPackage maps to KXDocument. This is the concrete
+implementation of the mapping table in Stage 5.
+
+### Frame Type → KX Kind
+
+```typescript
+const FRAME_TO_KX_KIND: Record<string, KXKind> = {
+  // Direct mappings
+  definition: "definition",
+  has_property: "property",
+  is_a: "classification",
+  consists_of: "classification",
+  taxonomy: "classification",
+  example_of: "example",
+  causal: "causal",
+  causal_chain: "causal",
+  heuristic: "heuristic",
+  principle: "principle",
+  procedure: "procedure",
+  method_comparison: "comparison",
+  threshold: "threshold",
+  deviation: "deviation",
+  formula: "evaluation",
+  sequence: "evaluation",
+  evaluation_matrix: "evaluation",
+};
+
+function frameToKXKind(frameType: string): KXKind {
+  return FRAME_TO_KX_KIND[frameType] ?? "property";
+  // Fallback: unknown domain-specific frames → "property"
+  // (safest generic — a claim about something)
+}
+```
+
+### Atom → KXUnit
+
+```typescript
+function atomToKXUnit(atom: Atom, sourceRef: string): KXUnit {
+  // Build content from roles — a readable natural language sentence.
+  // Each frame type has a content template.
+  const content = buildContent(atom);
+
+  return {
+    id: atom.id,
+    kind: frameToKXKind(atom.frame),
+    content,
+    roles: atom.roles,         // Passed through directly. Metis roles
+                               // ARE KX roles — same key-value structure.
+    conditions: atom.conditions,
+    confidence: atom.confidence,
+    source: {
+      ref: sourceRef,
+      location: formatLocation(atom.source),
+    },
+    domains: atom.domain,
+  };
+}
+```
+
+### Content Templates
+
+Each frame type has a template for generating the `content` field —
+a natural language sentence that any consumer can understand without
+knowing the frame schema.
+
+```typescript
+const CONTENT_TEMPLATES: Record<string, (roles: Record<string, string>) => string> = {
+  definition: (r) =>
+    `${r.term} means ${r.meaning}.`,
+  has_property: (r) =>
+    `${r.entity} has the property: ${r.property}.`,
+  is_a: (r) =>
+    `${r.instance} is a type of ${r.category}.`,
+  consists_of: (r) =>
+    `${r.whole} consists of ${r.dimension}${r.description ? `: ${r.description}` : ""}.`,
+  example_of: (r) =>
+    `${r.instance} is an example of ${r.concept}${r.detail ? ` — ${r.detail}` : ""}.`,
+  taxonomy: (r) =>
+    `${r.concept} is classified into: ${r.categories}${r.basis ? ` (by ${r.basis})` : ""}.`,
+  causal: (r) =>
+    `${r.cause} causes ${r.effect}.`,
+  causal_chain: (r) =>
+    `${r.trigger} leads to ${r.outcome}${r.mechanism ? ` via ${r.mechanism}` : ""}.`,
+  heuristic: (r) =>
+    `When ${r.situation}, ${r.action}${r.rationale ? ` because ${r.rationale}` : ""}.`,
+  principle: (r) =>
+    `${r.statement}${r.implication ? ` This implies: ${r.implication}` : ""}.`,
+  procedure: (r) =>
+    `To ${r.goal}: ${r.steps}.`,
+  method_comparison: (r) =>
+    `${r.method_a} vs ${r.method_b}: ${r.difference}${r.when_to_use ? `. ${r.when_to_use}` : ""}.`,
+  formula: (r) =>
+    `${r.name}: ${r.expression}${r.terms ? ` where ${r.terms}` : ""}.`,
+  threshold: (r) =>
+    `${r.metric} at ${r.threshold_value}: ${r.transition ?? "behavior changes"}${r.direction ? ` (${r.direction})` : ""}.`,
+  deviation: (r) =>
+    `Theory says ${r.theory}, but reality is ${r.reality}${r.implication ? `. ${r.implication}` : ""}.`,
+  sequence: (r) =>
+    `${r.name}: ${r.layers}${r.rule ? ` (${r.rule})` : ""}.`,
+  evaluation_matrix: (r) =>
+    `${r.name} evaluates along ${r.dimensions}${r.quadrants ? `: ${r.quadrants}` : ""}${r.rule ? `. ${r.rule}` : ""}.`,
+};
+
+function buildContent(atom: Atom): string {
+  const template = CONTENT_TEMPLATES[atom.frame];
+  if (template) {
+    return template(atom.roles);
+  }
+  // Fallback for domain-specific frames: concatenate role values
+  return Object.values(atom.roles).join(". ");
+}
+```
+
+### Relation Mapping
+
+```typescript
+function graphEdgeToKXRelation(
+  edge: GraphEdge,
+  fromId: string,
+): KXRelation | null {
+  // Only map semantic relations, not structural ones
+  const typeMap: Record<string, KXRelationType | null> = {
+    reinforces: "reinforces",
+    contradicts: "contradicts",
+    extends: "extends",
+    entity_link: null,        // Skip — structural, not semantic
+    cross_domain: null,       // Skip — structural, not semantic
+  };
+
+  const kxType = typeMap[edge.type];
+  if (!kxType) return null;
+
+  return {
+    from: fromId,
+    to: edge.target,
+    type: kxType,
+    confidence: edge.confidence,
+  };
+}
+```
+
+### Source Mapping
+
+```typescript
+function atomSourcesToKXSources(atoms: Atom[]): KXSource[] {
+  const seen = new Map<string, KXSource>();
+
+  for (const atom of atoms) {
+    const key = atom.source.title;
+    if (!seen.has(key)) {
+      seen.set(key, {
+        id: slugify(key),
+        type: "book",           // Default. Could infer from metadata.
+        title: atom.source.title,
+        authors: atom.source.authors,
+      });
+    }
+  }
+
+  return [...seen.values()];
+}
+
+function formatLocation(source: Atom["source"]): string {
+  const parts: string[] = [];
+  if (source.chapterId) parts.push(`Ch.${source.chapterId}`);
+  if (source.sectionId) parts.push(`§${source.sectionId}`);
+  return parts.join(", ") || undefined;
+}
+```
+
+### Full Export Function
+
+```typescript
+function exportToKX(pkg: ContextPackage): KXDocument {
+  const sources = atomSourcesToKXSources(
+    pkg.sections.flatMap(s => s.atoms),
+  );
+  const sourceRefMap = new Map(sources.map(s => [s.title, s.id]));
+
+  const units = pkg.sections.flatMap(section =>
+    section.atoms.map(atom =>
+      atomToKXUnit(atom, sourceRefMap.get(atom.source.title) ?? "unknown")
+    )
+  );
+
+  const relations = buildKXRelations(pkg);
+
+  return {
+    version: "kx/1.0",
+    meta: {
+      domains: [...new Set(units.flatMap(u => u.domains))],
+      sources,
+      generatedBy: "metis/0.1",
+      generatedAt: new Date().toISOString(),
+    },
+    units,
+    relations,
+  };
+}
+```
+
+### Gaps Sidecar Export
+
+Gaps are not knowledge — they're meta-information about coverage.
+Exported as a separate file alongside the KX document.
+
+```typescript
+interface GapsDocument {
+  version: "gaps/1.0";
+  query: string;
+  gaps: GapEntry[];
+  stats: {
+    totalAtomsRetrieved: number;
+    contradictionsFound: number;
+    gapsFound: number;
+  };
+}
+
+interface GapEntry {
+  type: "missing_domain" | "missing_frame_type" | "missing_entity"
+      | "thin_coverage" | "unresolved_contradiction";
+  description: string;
+  severity: "critical" | "notable" | "minor";
+  suggestion?: string;
+}
+```
+
+Output convention:
+```
+output/
+  {query-slug}.kx.json          # KX document
+  {query-slug}.gaps.json        # Gap analysis sidecar
+```
+
+---
+
 ## Open Questions
 
 1. **Section grouping strategy.** Group by entity, by domain, or by


### PR DESCRIPTION
## Summary

- **Appendix A:** Full query understanding prompt spec — system prompt, user prompt template, inventory construction, response schema, field normalization for snake_case
- **Appendix B:** Complete KX export mapping — frame-to-KX-kind map, content templates for all 17 frame types, relation mapping (semantic only, skip structural), source mapping, gaps sidecar format (`.gaps.json`)

These close the two spec gaps that would block Apply pipeline implementation.

## Test plan

- [ ] Verify content templates cover all 17 core frame types in `core-frames.json`
- [ ] Verify frame-to-KX-kind map matches the table in design/07

https://claude.ai/code/session_01V3y1S9TPfZwKGjx3Dphht5