### PR TITLE
fix: cap inventory size and handle Kimi markdown fencing

### DIFF
--- a/engine/src/apply/inventory.ts
+++ b/engine/src/apply/inventory.ts
@@ -6,6 +6,11 @@
 import type { KnowledgeGraph } from "../integrate/types";
 import type { GraphInventory } from "./types";
 
+const MAX_DOMAINS = 20;
+const MAX_ENTITIES = 50;
+const MAX_FRAME_TYPES = 20;
+const MAX_SOURCES = 20;
+
 export function buildInventory(graph: KnowledgeGraph): GraphInventory {
   const domainCounts = new Map<string, number>();
   const frameTypeCounts = new Map<string, number>();
@@ -26,17 +31,23 @@ export function buildInventory(graph: KnowledgeGraph): GraphInventory {
   return {
     domains: [...domainCounts.entries()]
       .map(([name, atomCount]) => ({ name, atomCount }))
-      .sort((a, b) => b.atomCount - a.atomCount),
-    entities: Object.values(graph.entities).map((e) => ({
-      name: e.canonicalName,
-      aliases: e.aliases,
-      domain: e.domain,
-    })),
+      .sort((a, b) => b.atomCount - a.atomCount)
+      .slice(0, MAX_DOMAINS),
+    entities: Object.values(graph.entities)
+      .map((e) => ({
+        name: e.canonicalName,
+        aliases: e.aliases,
+        domain: e.domain,
+      }))
+      .sort((a, b) => b.aliases.length - a.aliases.length)
+      .slice(0, MAX_ENTITIES),
     frameTypes: [...frameTypeCounts.entries()]
       .map(([name, count]) => ({ name, count }))
-      .sort((a, b) => b.count - a.count),
+      .sort((a, b) => b.count - a.count)
+      .slice(0, MAX_FRAME_TYPES),
     sources: [...sourceCounts.entries()]
       .map(([title, atomCount]) => ({ title, atomCount }))
-      .sort((a, b) => b.atomCount - a.atomCount),
+      .sort((a, b) => b.atomCount - a.atomCount)
+      .slice(0, MAX_SOURCES),
   };
 }

--- a/engine/src/apply/understand.ts
+++ b/engine/src/apply/understand.ts
@@ -27,11 +27,12 @@ export async function understand(
 		const response = await provider.sendMessage({
 			messages,
 			responseSchema: getQueryPlanSchema(),
-			maxTokens: 1024,
+			maxTokens: 4096,
 			temperature: 0.1,
 		});
 
-		const raw = JSON.parse(response.content) as Record<string, unknown>;
+		const cleaned = stripMarkdownFencing(response.content);
+		const raw = JSON.parse(cleaned) as Record<string, unknown>;
 		return normalizeQueryPlan(raw);
 	} catch (error) {
 		throw new ApplyError(
@@ -90,6 +91,17 @@ function getNumber(obj: Record<string, unknown>, ...keys: string[]): number {
 		if (typeof obj[key] === "number") return obj[key] as number;
 	}
 	return 0.5;
+}
+
+function stripMarkdownFencing(text: string): string {
+	const trimmed = text.trim();
+	if (trimmed.startsWith("```")) {
+		const lines = trimmed.split("\n");
+		// Remove first line (```json) and last line (```)
+		const inner = lines.slice(1, lines.length - 1).join("\n");
+		return inner.trim();
+	}
+	return trimmed;
 }
 
 function getGroupingStrategy(raw: Record<string, unknown>): GroupingStrategy {


### PR DESCRIPTION
## Summary
- Cap GraphInventory to top 20 domains, 50 entities, 20 frame types, 20 sources — prevents Kimi content filter rejection on large graphs
- Strip markdown code fencing (` ```json ... ``` `) from LLM responses before JSON parsing — Kimi wraps JSON in markdown despite "respond with valid JSON only" instruction

## Context
First real run of the Apply pipeline against the 8-book graph hit two issues:
1. Inventory prompt was too large (~500 entities) → Kimi rejected as "high risk"
2. After trimming, Kimi returned JSON wrapped in markdown fencing → parse failure

Both are provider quirks, not pipeline bugs. The fixes are defensive and work for all providers.

## Test plan
- [x] 394 tests pass
- [x] Full pipeline runs successfully with Kimi against real DDIA graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)